### PR TITLE
refactor: make `readConfigFile` synchronous

### DIFF
--- a/packages/honey-css-modules/src/config.test.ts
+++ b/packages/honey-css-modules/src/config.test.ts
@@ -17,7 +17,7 @@ describe.runIf(platform() !== 'win32')('readConfigFile', () => {
       `,
       'package.json': '{ "type": "module" }',
     });
-    expect(await readConfigFile(iff.rootDir)).toEqual({
+    expect(readConfigFile(iff.rootDir)).toEqual({
       pattern: 'src/**/*.module.css',
       dtsOutDir: 'generated/hcm',
     });
@@ -31,7 +31,7 @@ describe.runIf(platform() !== 'win32')('readConfigFile', () => {
         };
       `,
     });
-    expect(await readConfigFile(iff.rootDir)).toEqual({
+    expect(readConfigFile(iff.rootDir)).toEqual({
       pattern: 'src/**/*.module.css',
       dtsOutDir: 'generated/hcm',
     });
@@ -43,14 +43,14 @@ describe.runIf(platform() !== 'win32')('readConfigFile', () => {
         };
       `,
     });
-    expect(await readConfigFile(iff.rootDir)).toEqual({
+    expect(readConfigFile(iff.rootDir)).toEqual({
       pattern: 'src/**/*.module.css',
       dtsOutDir: 'generated/hcm',
     });
   });
   test('throws a ConfigNotFoundError if no config file is found', async () => {
     const iff = await createIFF({});
-    await expect(readConfigFile(iff.rootDir)).rejects.toThrow(ConfigNotFoundError);
+    expect(() => readConfigFile(iff.rootDir)).toThrow(ConfigNotFoundError);
   });
   test('throws error if config file has syntax errors', async () => {
     const iff = await createIFF({
@@ -58,13 +58,13 @@ describe.runIf(platform() !== 'win32')('readConfigFile', () => {
         export SYNTAX_ERROR;
       `,
     });
-    await expect(readConfigFile(iff.rootDir)).rejects.toThrow(ConfigImportError);
+    expect(() => readConfigFile(iff.rootDir)).toThrow(ConfigImportError);
   });
   test('throws error if config file has no default export', async () => {
     const iff = await createIFF({
       'hcm.config.mjs': 'export const config = {};',
     });
-    await expect(readConfigFile(iff.rootDir)).rejects.toThrowErrorMatchingInlineSnapshot(
+    expect(() => readConfigFile(iff.rootDir)).toThrowErrorMatchingInlineSnapshot(
       `[Error: Config must be a default export.]`,
     );
   });

--- a/packages/honey-css-modules/src/config.ts
+++ b/packages/honey-css-modules/src/config.ts
@@ -79,10 +79,11 @@ export function readConfigFile(cwd: string): HCMConfig {
       // However, `import(...)` does not accept a path like `C:\path\to\hcm.config.js`.
       // Therefore, we use `pathToFileURL` to convert it into a URL with the `file:///C:\path\to\hcm.config.js` scheme before importing.
       const resolvedPath = pathToFileURL(path).href;
-      // TODO: Fix problem with a old config file being read from import cache.
       module = JSON.parse(
         execFileSync('node', [
           '-e',
+          // NOTE: The module loaded by `import` is cached by Node.js runtime. So the user can't change the config file without restarting the process.
+          // This is an intentional limitation to simplify implementation.
           `import('${resolvedPath}')
             .then(m => process.stdout.write(
               JSON.stringify({

--- a/packages/ts-honey-css-modules-plugin/src/index.ts
+++ b/packages/ts-honey-css-modules-plugin/src/index.ts
@@ -16,6 +16,7 @@ const create: Create = async (ts, info) => {
 
   let config: HCMConfig;
   try {
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- TODO: remove await
     config = await readConfigFile(cwd);
     info.project.projectService.logger.info(`[ts-honey-css-modules-plugin] Loaded config: ${JSON.stringify(config)}`);
   } catch (error) {


### PR DESCRIPTION
Currently, the code generator is written in ESM. On the other hand, the entry point for ts-plugin is written in CJS. Therefore, ts-plugin loads code generator modules via dynamic import.

Dynamic import is an asynchronous API. Therefore, ts-plugin uses `createAsyncLanguageServicePlugin` for initialisation. However, there are some problems with `createAsyncLanguageServicePlugin`.

- https://github.com/volarjs/volar.js/issues/257
- https://github.com/volarjs/volar.js/issues/258

To work around these, we would like to initialise ts-plugin synchronously. So, first of all, we want to make config loading synchronous.
