### PR TITLE
refactor: make end position exclusive

### DIFF
--- a/packages/honey-css-modules/src/parser/css-module-parser.test.ts
+++ b/packages/honey-css-modules/src/parser/css-module-parser.test.ts
@@ -34,9 +34,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 6,
+                "column": 7,
                 "line": 1,
-                "offset": 5,
+                "offset": 6,
               },
               "start": {
                 "column": 2,
@@ -49,9 +49,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 10,
+                "column": 11,
                 "line": 2,
-                "offset": 19,
+                "offset": 20,
               },
               "start": {
                 "column": 2,
@@ -64,9 +64,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 10,
+                "column": 11,
                 "line": 3,
-                "offset": 33,
+                "offset": 34,
               },
               "start": {
                 "column": 2,
@@ -79,9 +79,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 15,
+                "column": 16,
                 "line": 4,
-                "offset": 52,
+                "offset": 53,
               },
               "start": {
                 "column": 2,
@@ -94,9 +94,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 15,
+                "column": 16,
                 "line": 5,
-                "offset": 71,
+                "offset": 72,
               },
               "start": {
                 "column": 2,
@@ -109,9 +109,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 20,
+                "column": 21,
                 "line": 6,
-                "offset": 101,
+                "offset": 102,
               },
               "start": {
                 "column": 7,
@@ -124,9 +124,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 20,
+                "column": 21,
                 "line": 7,
-                "offset": 126,
+                "offset": 127,
               },
               "start": {
                 "column": 2,
@@ -139,9 +139,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 40,
+                "column": 41,
                 "line": 7,
-                "offset": 146,
+                "offset": 147,
               },
               "start": {
                 "column": 22,
@@ -154,9 +154,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 13,
+                "column": 14,
                 "line": 8,
-                "offset": 163,
+                "offset": 164,
               },
               "start": {
                 "column": 2,
@@ -169,9 +169,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 29,
+                "column": 30,
                 "line": 8,
-                "offset": 179,
+                "offset": 180,
               },
               "start": {
                 "column": 18,
@@ -184,9 +184,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 12,
+                "column": 13,
                 "line": 11,
-                "offset": 264,
+                "offset": 265,
               },
               "start": {
                 "column": 6,
@@ -199,9 +199,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 16,
+                "column": 17,
                 "line": 14,
-                "offset": 290,
+                "offset": 291,
               },
               "start": {
                 "column": 2,
@@ -214,9 +214,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 34,
+                "column": 35,
                 "line": 14,
-                "offset": 308,
+                "offset": 309,
               },
               "start": {
                 "column": 20,
@@ -229,9 +229,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 15,
+                "column": 16,
                 "line": 15,
-                "offset": 327,
+                "offset": 328,
               },
               "start": {
                 "column": 9,
@@ -244,9 +244,9 @@ describe('parseCSSModuleCode', () => {
           {
             "loc": {
               "end": {
-                "column": 12,
+                "column": 13,
                 "line": 16,
-                "offset": 344,
+                "offset": 345,
               },
               "start": {
                 "column": 8,

--- a/packages/honey-css-modules/src/parser/location.test.ts
+++ b/packages/honey-css-modules/src/parser/location.test.ts
@@ -13,9 +13,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(basic!.rule, basic!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 6,
+          "column": 7,
           "line": 1,
-          "offset": 5,
+          "offset": 6,
         },
         "start": {
           "column": 2,
@@ -36,9 +36,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(cascading_1!.rule, cascading_1!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 10,
+          "column": 11,
           "line": 1,
-          "offset": 9,
+          "offset": 10,
         },
         "start": {
           "column": 2,
@@ -50,9 +50,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(cascading_2!.rule, cascading_2!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 10,
+          "column": 11,
           "line": 2,
-          "offset": 23,
+          "offset": 24,
         },
         "start": {
           "column": 2,
@@ -74,9 +74,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(pseudo_class_1!.rule, pseudo_class_1!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 15,
+          "column": 16,
           "line": 1,
-          "offset": 14,
+          "offset": 15,
         },
         "start": {
           "column": 2,
@@ -88,9 +88,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(pseudo_class_2!.rule, pseudo_class_2!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 15,
+          "column": 16,
           "line": 2,
-          "offset": 33,
+          "offset": 34,
         },
         "start": {
           "column": 2,
@@ -102,9 +102,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(pseudo_class_3!.rule, pseudo_class_3!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 20,
+          "column": 21,
           "line": 3,
-          "offset": 63,
+          "offset": 64,
         },
         "start": {
           "column": 7,
@@ -125,9 +125,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 20,
+            "column": 21,
             "line": 1,
-            "offset": 19,
+            "offset": 20,
           },
           "start": {
             "column": 2,
@@ -140,9 +140,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 40,
+            "column": 41,
             "line": 1,
-            "offset": 39,
+            "offset": 40,
           },
           "start": {
             "column": 22,
@@ -163,9 +163,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(combinator_1!.rule, combinator_1!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 13,
+          "column": 14,
           "line": 1,
-          "offset": 12,
+          "offset": 13,
         },
         "start": {
           "column": 2,
@@ -177,9 +177,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(combinator_2!.rule, combinator_2!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 29,
+          "column": 30,
           "line": 1,
-          "offset": 28,
+          "offset": 29,
         },
         "start": {
           "column": 18,
@@ -203,9 +203,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(at_rule!.rule, at_rule!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 12,
+          "column": 13,
           "line": 3,
-          "offset": 80,
+          "offset": 81,
         },
         "start": {
           "column": 6,
@@ -226,9 +226,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 16,
+            "column": 17,
             "line": 1,
-            "offset": 15,
+            "offset": 16,
           },
           "start": {
             "column": 2,
@@ -241,9 +241,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 34,
+            "column": 35,
             "line": 1,
-            "offset": 33,
+            "offset": 34,
           },
           "start": {
             "column": 20,
@@ -269,9 +269,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 26,
+            "column": 27,
             "line": 1,
-            "offset": 25,
+            "offset": 26,
           },
           "start": {
             "column": 9,
@@ -284,9 +284,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 21,
+            "column": 22,
             "line": 3,
-            "offset": 59,
+            "offset": 60,
           },
           "start": {
             "column": 4,
@@ -299,9 +299,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 21,
+            "column": 22,
             "line": 4,
-            "offset": 84,
+            "offset": 85,
           },
           "start": {
             "column": 4,
@@ -314,9 +314,9 @@ describe('getTokenLocationOfClassSelector', () => {
       .toMatchInlineSnapshot(`
         {
           "end": {
-            "column": 26,
+            "column": 27,
             "line": 6,
-            "offset": 116,
+            "offset": 117,
           },
           "start": {
             "column": 9,
@@ -338,9 +338,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(with_newline_1!.rule, with_newline_1!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 15,
+          "column": 16,
           "line": 1,
-          "offset": 14,
+          "offset": 15,
         },
         "start": {
           "column": 2,
@@ -352,9 +352,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(with_newline_2!.rule, with_newline_2!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 15,
+          "column": 16,
           "line": 2,
-          "offset": 31,
+          "offset": 32,
         },
         "start": {
           "column": 2,
@@ -366,9 +366,9 @@ describe('getTokenLocationOfClassSelector', () => {
     expect(getTokenLocationOfClassSelector(with_newline_3!.rule, with_newline_3!.classSelector)).toMatchInlineSnapshot(`
       {
         "end": {
-          "column": 19,
+          "column": 20,
           "line": 3,
-          "offset": 51,
+          "offset": 52,
         },
         "start": {
           "column": 6,
@@ -389,9 +389,9 @@ test('getTokenLocationOfAtValue', () => {
   expect(getTokenLocationOfAtValue(basic!, 'basic')).toMatchInlineSnapshot(`
     {
       "end": {
-        "column": 12,
+        "column": 13,
         "line": 1,
-        "offset": 11,
+        "offset": 12,
       },
       "start": {
         "column": 8,

--- a/packages/honey-css-modules/src/parser/location.ts
+++ b/packages/honey-css-modules/src/parser/location.ts
@@ -2,10 +2,16 @@ import type { AtRule, Rule } from 'postcss';
 import type { ClassName } from 'postcss-selector-parser';
 
 export interface Position {
-  /** The line number in the source file. It is 1-based (compatible with postcss). */
+  /**
+   * The line number in the source file. It is 1-based.
+   * This is compatible with postcss and tsserver.
+   */
   // TODO: Maybe it should be deleted since it is not used
   line: number;
-  /** The column number in the source file. It is 1-based (compatible with postcss). */
+  /**
+   * The column number in the source file. It is 1-based.
+   * This is compatible with postcss and tsserver.
+   */
   // TODO: Maybe it should be deleted since it is not used
   column: number;
   /** The offset in the source file. It is 0-based. */
@@ -13,9 +19,15 @@ export interface Position {
 }
 
 export interface Location {
-  /** The starting position of the node. It is inclusive (compatible with postcss). */
+  /**
+   * The starting position of the node. It is inclusive.
+   * This is compatible with postcss and tsserver.
+   */
   start: Position;
-  /** The ending position of the node. It is inclusive (compatible with postcss). */
+  /**
+   * The ending position of the node. It is exclusive.
+   * This is compatible with tsserver, but not postcss.
+   */
   // TODO: Maybe it should be deleted since it is not used
   end: Position;
 }
@@ -34,8 +46,8 @@ export function getTokenLocationOfAtValue(atValue: AtRule, name: string): Locati
   };
   const end = {
     line: start.line,
-    column: start.column + name.length - 1,
-    offset: start.offset + name.length - 1,
+    column: start.column + name.length,
+    offset: start.offset + name.length,
   };
   return { start, end };
 }
@@ -63,8 +75,8 @@ export function getTokenLocationOfClassSelector(rule: Rule, classSelector: Class
     // The end line is always the same as the start line, as a class selector cannot break in the middle.
     line: start.line,
     // The end column is the start column plus the length of the class selector.
-    column: start.column + classSelector.value.length - 1,
-    offset: start.offset + classSelector.value.length - 1,
+    column: start.column + classSelector.value.length,
+    offset: start.offset + classSelector.value.length,
   };
   return { start, end };
 }


### PR DESCRIPTION
The end position of the tsserver is exclusive. To avoid confusion, honey-css-modules should also match it.