### PR TITLE
JSDoc for hovering

### DIFF
--- a/example/generated/src/a.module.css.d.ts
+++ b/example/generated/src/a.module.css.d.ts
@@ -1,6 +1,21 @@
 declare const styles = {
+  /**
+   * ```css
+   * .a_1 { color: red; }
+   * ```
+   */
   a_1: '' as readonly string,
+  /**
+   * ```css
+   * .a_2 { color: red; }
+   * ```
+   */
   a_2: '' as readonly string,
+  /**
+   * ```css
+   * .a_2 { color: red; }
+   * ```
+   */
   a_2: '' as readonly string,
   a_3: '' as readonly string,
   ...(await import('./b.module.css')).default,

--- a/example/generated/src/b.module.css.d.ts
+++ b/example/generated/src/b.module.css.d.ts
@@ -1,4 +1,9 @@
 declare const styles = {
+  /**
+   * ```css
+   * .b_1 { color: red; }
+   * ```
+   */
   b_1: '' as readonly string,
   b_2: '' as readonly string,
 };

--- a/example/generated/src/d.module.css.d.ts
+++ b/example/generated/src/d.module.css.d.ts
@@ -1,4 +1,9 @@
 declare const styles = {
+  /**
+   * ```css
+   * .d_1 { color: red; }
+   * ```
+   */
   d_1: '' as readonly string,
 };
 export default styles;

--- a/packages/codegen/e2e/index.test.ts
+++ b/packages/codegen/e2e/index.test.ts
@@ -36,6 +36,11 @@ test('generates .d.ts', async () => {
   expect(hcm.status).toBe(0);
   expect(await readFile(iff.join('dist/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
     "declare const styles = {
+      /**
+       * \`\`\`css
+       * .a1 { color: red; }
+       * \`\`\`
+       */
       a1: '' as readonly string,
       ...(await import('./b.module.css')).default,
       ...(await import('@/c.module.css')).default,
@@ -45,6 +50,11 @@ test('generates .d.ts', async () => {
   `);
   expect(await readFile(iff.join('dist/src/b.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
     "declare const styles = {
+      /**
+       * \`\`\`css
+       * .b1 { color: red; }
+       * \`\`\`
+       */
       b1: '' as readonly string,
     };
     export default styles;
@@ -52,6 +62,11 @@ test('generates .d.ts', async () => {
   `);
   expect(await readFile(iff.join('dist/src/c.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
     "declare const styles = {
+      /**
+       * \`\`\`css
+       * .c1 { color: red; }
+       * \`\`\`
+       */
       c1: '' as readonly string,
     };
     export default styles;

--- a/packages/codegen/src/dts-creator.ts
+++ b/packages/codegen/src/dts-creator.ts
@@ -78,6 +78,16 @@ export function createDts(
   let code = 'declare const styles = {\n';
   for (const token of localTokens) {
     code += `  `;
+    if (token.definition) {
+      const cssLines = token.definition.trim().split('\n');
+      code += '/**\n';
+      code += `   * \`\`\`css\n`;
+      for (const line of cssLines) {
+        code += `   * ${line}\n`;
+      }
+      code += `   * \`\`\`\n`;
+      code += `   */\n  `;
+    }
     mapping.sourceOffsets.push(token.loc.start.offset);
     mapping.generatedOffsets.push(code.length);
     mapping.lengths.push(token.name.length);

--- a/packages/codegen/src/parser/css-module-parser.test.ts
+++ b/packages/codegen/src/parser/css-module-parser.test.ts
@@ -32,6 +32,7 @@ describe('parseCSSModuleCode', () => {
         "filename": "/test.module.css",
         "localTokens": [
           {
+            "definition": ".basic {}",
             "loc": {
               "end": {
                 "column": 7,
@@ -47,6 +48,7 @@ describe('parseCSSModuleCode', () => {
             "name": "basic",
           },
           {
+            "definition": ".cascading {}",
             "loc": {
               "end": {
                 "column": 11,
@@ -62,6 +64,7 @@ describe('parseCSSModuleCode', () => {
             "name": "cascading",
           },
           {
+            "definition": ".cascading {}",
             "loc": {
               "end": {
                 "column": 11,
@@ -77,6 +80,7 @@ describe('parseCSSModuleCode', () => {
             "name": "cascading",
           },
           {
+            "definition": ".pseudo_class_1 {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -92,6 +96,7 @@ describe('parseCSSModuleCode', () => {
             "name": "pseudo_class_1",
           },
           {
+            "definition": ".pseudo_class_2:hover {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -107,6 +112,7 @@ describe('parseCSSModuleCode', () => {
             "name": "pseudo_class_2",
           },
           {
+            "definition": ":not(.pseudo_class_3) {}",
             "loc": {
               "end": {
                 "column": 21,
@@ -122,6 +128,7 @@ describe('parseCSSModuleCode', () => {
             "name": "pseudo_class_3",
           },
           {
+            "definition": ".multiple_selector_1.multiple_selector_2 {}",
             "loc": {
               "end": {
                 "column": 21,
@@ -137,6 +144,7 @@ describe('parseCSSModuleCode', () => {
             "name": "multiple_selector_1",
           },
           {
+            "definition": ".multiple_selector_1.multiple_selector_2 {}",
             "loc": {
               "end": {
                 "column": 41,
@@ -152,6 +160,7 @@ describe('parseCSSModuleCode', () => {
             "name": "multiple_selector_2",
           },
           {
+            "definition": ".combinator_1 + .combinator_2 {}",
             "loc": {
               "end": {
                 "column": 14,
@@ -167,6 +176,7 @@ describe('parseCSSModuleCode', () => {
             "name": "combinator_1",
           },
           {
+            "definition": ".combinator_1 + .combinator_2 {}",
             "loc": {
               "end": {
                 "column": 30,
@@ -182,6 +192,7 @@ describe('parseCSSModuleCode', () => {
             "name": "combinator_2",
           },
           {
+            "definition": ".at_rule {}",
             "loc": {
               "end": {
                 "column": 13,
@@ -197,6 +208,7 @@ describe('parseCSSModuleCode', () => {
             "name": "at_rule",
           },
           {
+            "definition": ".selector_list_1, .selector_list_2 {}",
             "loc": {
               "end": {
                 "column": 17,
@@ -212,6 +224,7 @@ describe('parseCSSModuleCode', () => {
             "name": "selector_list_1",
           },
           {
+            "definition": ".selector_list_1, .selector_list_2 {}",
             "loc": {
               "end": {
                 "column": 35,
@@ -227,6 +240,7 @@ describe('parseCSSModuleCode', () => {
             "name": "selector_list_2",
           },
           {
+            "definition": ":local(.local_1) {}",
             "loc": {
               "end": {
                 "column": 16,

--- a/packages/codegen/src/parser/css-module-parser.ts
+++ b/packages/codegen/src/parser/css-module-parser.ts
@@ -62,6 +62,8 @@ export interface Token {
   name: string;
   /** The location of the token in the source file. */
   loc: Location;
+  /** The style definition of the token. */
+  definition?: string;
 }
 
 /**

--- a/packages/codegen/src/parser/rule-parser.test.ts
+++ b/packages/codegen/src/parser/rule-parser.test.ts
@@ -37,6 +37,7 @@ describe('parseRule', () => {
       [
         [
           {
+            "definition": ".basic {}",
             "loc": {
               "end": {
                 "column": 7,
@@ -54,6 +55,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".cascading {}",
             "loc": {
               "end": {
                 "column": 11,
@@ -71,6 +73,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".cascading {}",
             "loc": {
               "end": {
                 "column": 11,
@@ -88,6 +91,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".pseudo_class_1 {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -105,6 +109,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".pseudo_class_2:hover {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -122,6 +127,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ":not(.pseudo_class_3) {}",
             "loc": {
               "end": {
                 "column": 21,
@@ -139,6 +145,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".multiple_selector_1.multiple_selector_2 {}",
             "loc": {
               "end": {
                 "column": 21,
@@ -154,6 +161,7 @@ describe('parseRule', () => {
             "name": "multiple_selector_1",
           },
           {
+            "definition": ".multiple_selector_1.multiple_selector_2 {}",
             "loc": {
               "end": {
                 "column": 41,
@@ -171,6 +179,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".combinator_1 + .combinator_2 {}",
             "loc": {
               "end": {
                 "column": 14,
@@ -186,6 +195,7 @@ describe('parseRule', () => {
             "name": "combinator_1",
           },
           {
+            "definition": ".combinator_1 + .combinator_2 {}",
             "loc": {
               "end": {
                 "column": 30,
@@ -203,6 +213,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".at_rule {}",
             "loc": {
               "end": {
                 "column": 13,
@@ -220,6 +231,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".selector_list_1, .selector_list_2 {}",
             "loc": {
               "end": {
                 "column": 17,
@@ -235,6 +247,7 @@ describe('parseRule', () => {
             "name": "selector_list_1",
           },
           {
+            "definition": ".selector_list_1, .selector_list_2 {}",
             "loc": {
               "end": {
                 "column": 35,
@@ -252,6 +265,7 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ":local(.local_class_name_1) {}",
             "loc": {
               "end": {
                 "column": 27,
@@ -269,6 +283,9 @@ describe('parseRule', () => {
         ],
         [
           {
+            "definition": ".with_newline_1,
+      .with_newline_2
+        + .with_newline_3, {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -284,6 +301,9 @@ describe('parseRule', () => {
             "name": "with_newline_1",
           },
           {
+            "definition": ".with_newline_1,
+      .with_newline_2
+        + .with_newline_3, {}",
             "loc": {
               "end": {
                 "column": 16,
@@ -299,6 +319,9 @@ describe('parseRule', () => {
             "name": "with_newline_2",
           },
           {
+            "definition": ".with_newline_1,
+      .with_newline_2
+        + .with_newline_3, {}",
             "loc": {
               "end": {
                 "column": 20,

--- a/packages/codegen/src/parser/rule-parser.ts
+++ b/packages/codegen/src/parser/rule-parser.ts
@@ -61,6 +61,8 @@ interface ClassSelector {
   name: string;
   /** The location of the class selector. */
   loc: Location;
+  /** The style definition of the class selector */
+  definition: string;
 }
 
 /**
@@ -87,6 +89,7 @@ export function parseRule(rule: Rule): ClassSelector[] {
     return {
       name: className.value,
       loc: { start, end },
+      definition: rule.toString(),
     };
   });
 }

--- a/packages/codegen/src/runner.test.ts
+++ b/packages/codegen/src/runner.test.ts
@@ -13,6 +13,11 @@ describe('runHCM', () => {
     await runHCM({ pattern: 'src/**/*.module.css', dtsOutDir: 'generated' }, iff.rootDir);
     expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
       "declare const styles = {
+        /**
+         * \`\`\`css
+         * .a1 { color: red; }
+         * \`\`\`
+         */
         a1: '' as readonly string,
       };
       export default styles;
@@ -20,6 +25,11 @@ describe('runHCM', () => {
     `);
     expect(await readFile(iff.join('generated/src/b.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
       "declare const styles = {
+        /**
+         * \`\`\`css
+         * .b1 { color: blue; }
+         * \`\`\`
+         */
         b1: '' as readonly string,
       };
       export default styles;
@@ -67,6 +77,11 @@ describe('runHCM', () => {
     await runHCM({ pattern: './src/**/*.module.css', dtsOutDir: 'generated' }, iff.rootDir);
     expect(await readFile(iff.join('generated/src/a.module.css.d.ts'), 'utf-8')).toMatchInlineSnapshot(`
       "declare const styles = {
+        /**
+         * \`\`\`css
+         * .a1 { color: red; }
+         * \`\`\`
+         */
         a1: '' as readonly string,
       };
       export default styles;


### PR DESCRIPTION
Now, we can inspect style definition from TypeScript (or JavaScript) code.
You don't need to open css files.

![image](https://github.com/user-attachments/assets/dc6755b9-0156-462d-94a2-feed9dd7ea7d)

