### PR TITLE
Use `postcss-safe-parser` in ts-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@mizdra/prettier-config-mizdra": "^2.0.0",
         "@types/eslint": "^9.6.1",
         "@types/node": "^22.10.2",
+        "@types/postcss-safe-parser": "^5.0.4",
         "@types/vscode": "^1.96.0",
         "@typescript/server-harness": "^0.3.5",
         "dedent": "^1.5.3",
@@ -1194,6 +1195,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/postcss-safe-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/postcss-safe-parser/-/postcss-safe-parser-5.0.4.tgz",
+      "integrity": "sha512-5zGTm1jsW3j4+omgND1SIDbrZOcigTuxa4ihppvKbLkg2INUGBHV/fWNRSRFibK084tU3fxqZ/kVoSIGqRHnrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.4"
       }
     },
     "node_modules/@types/vscode": {
@@ -6701,6 +6712,7 @@
       "dependencies": {
         "glob": "^11.0.0",
         "postcss": "^8.4.49",
+        "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mizdra/prettier-config-mizdra": "^2.0.0",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.10.2",
+    "@types/postcss-safe-parser": "^5.0.4",
     "@types/vscode": "^1.96.0",
     "@typescript/server-harness": "^0.3.5",
     "dedent": "^1.5.3",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "glob": "^11.0.0",
     "postcss": "^8.4.49",
+    "postcss-safe-parser": "^7.0.1",
     "postcss-selector-parser": "^7.0.0",
     "postcss-value-parser": "^4.2.0"
   },

--- a/packages/codegen/src/parser/css-module-parser.ts
+++ b/packages/codegen/src/parser/css-module-parser.ts
@@ -1,5 +1,6 @@
 import type { AtRule, Node, Root, Rule } from 'postcss';
 import { parse } from 'postcss';
+import safeParser from 'postcss-safe-parser';
 import { CSSModuleParseError } from '../error.js';
 import { parseAtImport } from './at-import-parser.js';
 import { parseAtValue } from './at-value-parser.js';
@@ -148,6 +149,7 @@ export interface CSSModuleFile {
 export interface ParseCSSModuleCodeOptions {
   filename: string;
   dashedIdents: boolean;
+  safe: boolean;
 }
 
 interface ParseCSSModuleCodeResult {
@@ -158,10 +160,14 @@ interface ParseCSSModuleCodeResult {
 /**
  * @throws {CSSModuleParseError}
  */
-export function parseCSSModuleCode(code: string, { filename }: ParseCSSModuleCodeOptions): ParseCSSModuleCodeResult {
+export function parseCSSModuleCode(
+  code: string,
+  { filename, safe }: ParseCSSModuleCodeOptions,
+): ParseCSSModuleCodeResult {
   let ast: Root;
   try {
-    ast = parse(code, { from: filename });
+    const parser = safe ? safeParser : parse;
+    ast = parser(code, { from: filename });
   } catch (e) {
     throw new CSSModuleParseError(filename, e);
   }

--- a/packages/codegen/src/runner.ts
+++ b/packages/codegen/src/runner.ts
@@ -26,7 +26,7 @@ async function processFile(
   } catch (error) {
     throw new ReadCSSModuleFileError(filename, error);
   }
-  const { cssModule } = parseCSSModuleCode(code, { filename, dashedIdents });
+  const { cssModule } = parseCSSModuleCode(code, { filename, dashedIdents, safe: false });
   if (cssModule === undefined) {
     // TODO: Report diagnostics
     return;

--- a/packages/ts-plugin/e2e/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e/go-to-definition.test.ts
@@ -1,24 +1,9 @@
 import dedent from 'dedent';
-import type ts from 'typescript';
 import { describe, expect, test } from 'vitest';
 import { createIFF } from './test/fixture.js';
-import { formatPath, launchTsserver } from './test/tsserver.js';
+import { formatPath, launchTsserver, simplifyDefinitions, sortDefinitions } from './test/tsserver.js';
 
 describe('Go to Definition', async () => {
-  function simplifyDefinitions(definitions: readonly ts.server.protocol.DefinitionInfo[]) {
-    return definitions.map((definition) => {
-      return {
-        file: formatPath(definition.file),
-        start: definition.start,
-        end: definition.end,
-      };
-    });
-  }
-  function sortDefinitions(definitions: readonly ts.server.protocol.DefinitionInfo[]) {
-    return definitions.toSorted((a, b) => {
-      return a.file.localeCompare(b.file) || a.start.line - b.start.line || a.start.offset - b.start.offset;
-    });
-  }
   const tsserver = launchTsserver();
   const iff = await createIFF({
     'index.ts': dedent`

--- a/packages/ts-plugin/e2e/invalid-syntax.test.ts
+++ b/packages/ts-plugin/e2e/invalid-syntax.test.ts
@@ -1,0 +1,45 @@
+import dedent from 'dedent';
+import { expect, test } from 'vitest';
+import { createIFF } from './test/fixture.js';
+import { formatPath, launchTsserver, simplifyDefinitions, sortDefinitions } from './test/tsserver.js';
+
+test('handle invalid syntax CSS without crashing', async () => {
+  const tsserver = launchTsserver();
+  const iff = await createIFF({
+    'index.ts': dedent`
+      import styles from './a.module.css';
+      styles.a_1;
+    `,
+    'a.module.css': dedent`
+      .a_1 { color: red; }
+      .a_2 {
+    `,
+    'hcm.config.mjs': dedent`
+      export default {
+        pattern: '**/*.module.css',
+        dtsOutDir: 'generated',
+      };
+    `,
+    'tsconfig.json': dedent`
+      {
+        "compilerOptions": {}
+      }
+    `,
+  });
+  await tsserver.sendUpdateOpen({
+    openFiles: [{ file: iff.paths['index.ts'] }],
+  });
+  const res = await tsserver.sendDefinitionAndBoundSpan({
+    file: iff.paths['index.ts'],
+    line: 2,
+    offset: 8,
+  });
+  const expected = [
+    {
+      file: formatPath(iff.paths['a.module.css']),
+      start: { line: 1, offset: 2 },
+      end: { line: 1, offset: 5 },
+    },
+  ];
+  expect(sortDefinitions(simplifyDefinitions(res.body?.definitions ?? []))).toStrictEqual(sortDefinitions(expected));
+});

--- a/packages/ts-plugin/e2e/test/tsserver.ts
+++ b/packages/ts-plugin/e2e/test/tsserver.ts
@@ -1,5 +1,6 @@
 import serverHarness from '@typescript/server-harness';
 import type { server } from 'typescript';
+import type ts from 'typescript';
 
 interface Tsserver {
   sendUpdateOpen(args: server.protocol.UpdateOpenRequest['arguments']): Promise<server.protocol.Response>;
@@ -59,4 +60,19 @@ export function launchTsserver(): Tsserver {
 export function formatPath(path: string) {
   // In windows, tsserver returns paths with '/' instead of '\\'.
   return path.replaceAll('\\', '/');
+}
+
+export function simplifyDefinitions(definitions: readonly ts.server.protocol.DefinitionInfo[]) {
+  return definitions.map((definition) => {
+    return {
+      file: formatPath(definition.file),
+      start: definition.start,
+      end: definition.end,
+    };
+  });
+}
+export function sortDefinitions(definitions: readonly ts.server.protocol.DefinitionInfo[]) {
+  return definitions.toSorted((a, b) => {
+    return a.file.localeCompare(b.file) || a.start.line - b.start.line || a.start.offset - b.start.offset;
+  });
 }

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -24,7 +24,9 @@ export function createCSSModuleLanguagePlugin(
       const { cssModule } = parseCSSModuleCode(cssModuleCode, {
         filename: scriptId,
         dashedIdents: config.dashedIdents,
-        safe: false,
+        // The CSS in the process of being written in an editor often contains invalid syntax.
+        // So, ts-plugin uses a fault-tolerant Parser to parse CSS.
+        safe: true,
       });
       // TODO: Report diagnostics
       if (cssModule === undefined) return undefined;

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -24,6 +24,7 @@ export function createCSSModuleLanguagePlugin(
       const { cssModule } = parseCSSModuleCode(cssModuleCode, {
         filename: scriptId,
         dashedIdents: config.dashedIdents,
+        safe: false,
       });
       // TODO: Report diagnostics
       if (cssModule === undefined) return undefined;


### PR DESCRIPTION
ref: #58 

Make ts-plugin use postcss-safe-parser to parse CSS. This allows ts-plugin to handle broken CSS.

## Before

Previously, writing broken CSS would cause tsserver to crash.

<img width="827" alt="image" src="https://github.com/user-attachments/assets/0321ae2b-c94e-4bda-9695-39836ba01ae1" />

## After

<img width="819" alt="image" src="https://github.com/user-attachments/assets/59b396e2-6b4e-4068-b81a-e4197e89eb3f" />

