### PR TITLE
Revert "feat!: resolve alias with `paths`"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6740,9 +6740,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.7.3"
       }
     },
     "packages/language-server": {

--- a/packages/codegen/e2e/index.test.ts
+++ b/packages/codegen/e2e/index.test.ts
@@ -21,7 +21,7 @@ test('generates .d.ts', async () => {
       export default {
         pattern: 'src/**/*.module.css',
         dtsOutDir: 'dist',
-        paths: { '@/*': ['./src/*'] },
+        alias: { '@': 'src' },
       };
     `,
   });

--- a/packages/codegen/src/runner.ts
+++ b/packages/codegen/src/runner.ts
@@ -49,8 +49,8 @@ async function processFile(
  */
 export async function runHCM(config: HCMConfig, cwd: string, logger: Logger): Promise<void> {
   const resolvedConfig = resolveConfig(config, cwd);
-  const { pattern, paths } = resolvedConfig;
-  const resolver = createResolver(paths, cwd);
+  const { pattern, alias } = resolvedConfig;
+  const resolver = createResolver(alias, cwd);
   const isExternalFile = createIsExternalFile(resolvedConfig);
 
   const promises: Promise<Diagnostic[]>[] = [];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,8 +47,5 @@
     "postcss-safe-parser": "^7.0.1",
     "postcss-selector-parser": "^7.0.0",
     "postcss-value-parser": "^4.2.0"
-  },
-  "peerDependencies": {
-    "typescript": "^5.7.3"
   }
 }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -80,17 +80,14 @@ test('assertConfig', () => {
     `[Error: \`dtsOutDir\` must be a string.]`,
   );
   expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str' })).not.toThrow();
-  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', paths: 1 })).toThrowErrorMatchingInlineSnapshot(
-    `[Error: \`paths\` must be an object.]`,
+  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', alias: 1 })).toThrowErrorMatchingInlineSnapshot(
+    `[Error: \`alias\` must be an object.]`,
   );
-  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', paths: {} })).not.toThrow();
+  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', alias: {} })).not.toThrow();
   expect(() =>
-    assertConfig({ pattern: 'str', dtsOutDir: 'str', paths: { '@/*': 1 } }),
-  ).toThrowErrorMatchingInlineSnapshot(`[Error: \`paths["@/*"]\` must be an array.]`);
-  expect(() =>
-    assertConfig({ pattern: 'str', dtsOutDir: 'str', paths: { '@/*': [1] } }),
-  ).toThrowErrorMatchingInlineSnapshot(`[Error: \`paths["@/*"][0]\` must be a string.]`);
-  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', paths: { '@/*': ['./*'] } })).not.toThrow();
+    assertConfig({ pattern: 'str', dtsOutDir: 'str', alias: { str: 1 } }),
+  ).toThrowErrorMatchingInlineSnapshot(`[Error: \`alias.str\` must be a string.]`);
+  expect(() => assertConfig({ pattern: 'str', dtsOutDir: 'str', alias: { str: 'str' } })).not.toThrow();
   expect(() =>
     assertConfig({ pattern: 'str', dtsOutDir: 'str', arbitraryExtensions: 1 }),
   ).toThrowErrorMatchingInlineSnapshot(`[Error: \`arbitraryExtensions\` must be a boolean.]`);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,7 +10,7 @@ const ALLOWED_CONFIG_FILE_EXTENSIONS = ['js', 'mjs', 'cjs'];
 export interface HCMConfig {
   pattern: string;
   dtsOutDir: string;
-  paths?: Record<string, string[]> | undefined;
+  alias?: Record<string, string> | undefined;
   arbitraryExtensions?: boolean | undefined;
   dashedIdents?: boolean | undefined;
 }
@@ -19,18 +19,13 @@ export function defineConfig(config: HCMConfig): HCMConfig {
   return config;
 }
 
-function assertPaths(paths: unknown): asserts paths is Record<string, string[]> {
-  if (typeof paths !== 'object' || paths === null) {
-    throw new ConfigValidationError('`paths` must be an object.');
+function assertAlias(alias: unknown): asserts alias is Record<string, string> {
+  if (typeof alias !== 'object' || alias === null) {
+    throw new ConfigValidationError('`alias` must be an object.');
   }
-  for (const [key, array] of Object.entries(paths)) {
-    if (!Array.isArray(array)) {
-      throw new ConfigValidationError(`\`paths[${JSON.stringify(key)}]\` must be an array.`);
-    }
-    for (let i = 0; i < array.length; i++) {
-      if (typeof array[i] !== 'string') {
-        throw new ConfigValidationError(`\`paths[${JSON.stringify(key)}][${i}]\` must be a string.`);
-      }
+  for (const [key, value] of Object.entries(alias)) {
+    if (typeof value !== 'string') {
+      throw new ConfigValidationError(`\`alias.${key}\` must be a string.`);
     }
   }
 }
@@ -44,7 +39,7 @@ export function assertConfig(config: unknown): asserts config is HCMConfig {
   if (typeof config.pattern !== 'string') throw new ConfigValidationError('`pattern` must be a string.');
   if (!('dtsOutDir' in config)) throw new ConfigValidationError('`dtsOutDir` is required.');
   if (typeof config.dtsOutDir !== 'string') throw new ConfigValidationError('`dtsOutDir` must be a string.');
-  if ('paths' in config) assertPaths(config.paths);
+  if ('alias' in config) assertAlias(config.alias);
   if ('arbitraryExtensions' in config && typeof config.arbitraryExtensions !== 'boolean') {
     throw new ConfigValidationError('`arbitraryExtensions` must be a boolean.');
   }
@@ -102,7 +97,7 @@ export function readConfigFile(cwd: string): HCMConfig {
 export interface ResolvedHCMConfig {
   pattern: string;
   dtsOutDir: string;
-  paths: Record<string, string[]>;
+  alias: Record<string, string>;
   arbitraryExtensions: boolean;
   dashedIdents: boolean;
   cwd: string;
@@ -111,7 +106,7 @@ export interface ResolvedHCMConfig {
 export function resolveConfig(config: HCMConfig, cwd: string): ResolvedHCMConfig {
   return {
     ...config,
-    paths: config.paths ?? {},
+    alias: config.alias ?? {},
     arbitraryExtensions: config.arbitraryExtensions ?? false,
     dashedIdents: config.dashedIdents ?? false,
     cwd,

--- a/packages/core/src/resolver.test.ts
+++ b/packages/core/src/resolver.test.ts
@@ -1,36 +1,46 @@
+import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { createResolver } from './resolver.js';
-import { createIFF } from './test/fixture.js';
 
-describe('createResolver', async () => {
-  const iff = await createIFF({
-    'request.module.css': '',
-    'a.module.css': '',
-    'dir/a.module.css': '',
-    'paths1/a.module.css': '',
-    'paths2/b.module.css': '',
-    'paths3/c.module.css': '',
-  });
-  const request = iff.paths['request.module.css'];
+describe('createResolver', () => {
   test('resolves relative path', () => {
-    const resolve = createResolver({}, iff.rootDir);
-    expect(resolve('./a.module.css', { request })).toBe(iff.paths['a.module.css']);
-    expect(resolve('./dir/a.module.css', { request })).toBe(iff.paths['dir/a.module.css']);
+    const resolve = createResolver({}, '/app');
+    expect(resolve('./a.module.css', { request: '/app/request.module.css' })).toBe(path.resolve('/app/a.module.css'));
+    expect(resolve('./dir/a.module.css', { request: '/app/request.module.css' })).toBe(
+      path.resolve('/app/dir/a.module.css'),
+    );
   });
-  describe('resolves paths', () => {
-    test('paths is used if import specifiers start with paths', () => {
-      const resolve = createResolver({ '@/*': ['./paths1/*', './paths2/*'], '#/*': ['./paths3/*'] }, iff.rootDir);
-      expect(resolve('@/a.module.css', { request })).toBe(iff.paths['paths1/a.module.css']);
-      expect(resolve('@/b.module.css', { request })).toBe(iff.paths['paths2/b.module.css']);
-      expect(resolve('#/c.module.css', { request })).toBe(iff.paths['paths3/c.module.css']);
-      expect(resolve('@/d.module.css', { request })).toBe(undefined);
+  describe('resolves alias', () => {
+    test('alias is used if import specifiers start with alias', () => {
+      const resolve = createResolver({ '@': './alias', '#': 'alias' }, '/app');
+      expect(resolve('@/a.module.css', { request: '/app/request.module.css' })).toBe(
+        path.resolve('/app/alias/a.module.css'),
+      );
+      expect(resolve('./@/a.module.css', { request: '/app/request.module.css' })).toBe(
+        path.resolve('/app/@/a.module.css'),
+      );
+      expect(resolve('@/dir/a.module.css', { request: '/app/request.module.css' })).toBe(
+        path.resolve('/app/alias/dir/a.module.css'),
+      );
+      expect(resolve('@/a.module.css', { request: '/app/dir/request.module.css' })).toBe(
+        path.resolve('/app/alias/a.module.css'),
+      );
+      expect(resolve('#/a.module.css', { request: '/app/request.module.css' })).toBe(
+        path.resolve('/app/alias/a.module.css'),
+      );
+    });
+    test('the first alias is used if multiple aliases match', () => {
+      const resolve = createResolver({ '@': './alias1', '@@': './alias2' }, '/app');
+      expect(resolve('@/a.module.css', { request: '/app/request.module.css' })).toBe(
+        path.resolve('/app/alias1/a.module.css'),
+      );
     });
   });
   test('does not resolve invalid path', () => {
-    const resolve = createResolver({}, iff.rootDir);
-    expect(resolve('http://example.com', { request })).toBe(undefined);
-    expect(resolve('package', { request })).toBe(undefined);
-    expect(resolve('@scope/package', { request })).toBe(undefined);
-    expect(resolve('~package', { request })).toBe(undefined);
+    const resolve = createResolver({}, '/app');
+    expect(resolve('http://example.com', { request: '/app/request.module.css' })).toBe(undefined);
+    expect(resolve('package', { request: '/app/request.module.css' })).toBe(undefined);
+    expect(resolve('@scope/package', { request: '/app/request.module.css' })).toBe(undefined);
+    expect(resolve('~package', { request: '/app/request.module.css' })).toBe(undefined);
   });
 });

--- a/packages/ts-plugin/e2e/go-to-definition.test.ts
+++ b/packages/ts-plugin/e2e/go-to-definition.test.ts
@@ -14,6 +14,7 @@ describe('Go to Definition', async () => {
       styles.b_1;
       styles.c_1;
       styles.c_alias;
+      styles.d_1;
     `,
     'a.module.css': dedent`
       @import './b.module.css';
@@ -23,6 +24,7 @@ describe('Go to Definition', async () => {
       .a_2 { color: red; }
       @value a_3: red;
       @import url(./b.module.css);
+      @import '@/d.module.css';
     `,
     'b.module.css': dedent`
       .b_1 { color: red; }
@@ -31,15 +33,21 @@ describe('Go to Definition', async () => {
       @value c_1: red;
       @value c_2: red;
     `,
+    'd.module.css': dedent`
+      .d_1 { color: red; }
+    `,
     'hcm.config.mjs': dedent`
       export default {
         pattern: '**/*.module.css',
         dtsOutDir: 'generated',
+        alias: { '@': '.' },
       };
     `,
     'tsconfig.json': dedent`
       {
-        "compilerOptions": {}
+        "compilerOptions": {
+          "paths": { '@/*': ['./*'] }
+        }
       }
     `,
   });
@@ -81,6 +89,15 @@ describe('Go to Definition', async () => {
       offset: 33,
       expected: [
         { file: formatPath(iff.paths['c.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
+      ],
+    },
+    {
+      name: "'./d.module.css' in a.module.css",
+      file: iff.paths['a.module.css'],
+      line: 8,
+      offset: 9,
+      expected: [
+        { file: formatPath(iff.paths['d.module.css']), start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 } },
       ],
     },
     {
@@ -170,6 +187,15 @@ describe('Go to Definition', async () => {
       expected: [
         { file: formatPath(iff.paths['a.module.css']), start: { line: 2, offset: 20 }, end: { line: 2, offset: 27 } },
         { file: formatPath(iff.paths['c.module.css']), start: { line: 2, offset: 8 }, end: { line: 2, offset: 11 } },
+      ],
+    },
+    {
+      name: 'd_1 in index.ts',
+      file: iff.paths['index.ts'],
+      line: 8,
+      offset: 8,
+      expected: [
+        { file: formatPath(iff.paths['d.module.css']), start: { line: 1, offset: 2 }, end: { line: 1, offset: 5 } },
       ],
     },
     {

--- a/packages/ts-plugin/e2e/rename-file.test.ts
+++ b/packages/ts-plugin/e2e/rename-file.test.ts
@@ -12,6 +12,7 @@ describe('Rename File', async () => {
     'a.module.css': dedent`
       @import './b.module.css';
       @value c_1 from './c.module.css';
+      @import '@/d.module.css';
     `,
     'b.module.css': dedent`
       .b_1 { color: red; }
@@ -19,15 +20,21 @@ describe('Rename File', async () => {
     'c.module.css': dedent`
       @value c_1: red;
     `,
+    'd.module.css': dedent`
+      .d_1 { color: red; }
+    `,
     'hcm.config.mjs': dedent`
       export default {
         pattern: '**/*.module.css',
         dtsOutDir: 'generated',
+        alias: { '@': '.' },
       };
     `,
     'tsconfig.json': dedent`
       {
-        "compilerOptions": {}
+        "compilerOptions": {
+          "paths": { '@/*': ['./*'] }
+        }
       }
     `,
   });
@@ -65,6 +72,17 @@ describe('Rename File', async () => {
         {
           fileName: formatPath(iff.paths['a.module.css']),
           textChanges: [{ start: { line: 2, offset: 18 }, end: { line: 2, offset: 32 }, newText: './cc.module.css' }],
+        },
+      ],
+    },
+    {
+      name: 'd.module.css',
+      oldFilePath: iff.paths['d.module.css'],
+      newFilePath: iff.join('dd.module.css'),
+      expected: [
+        {
+          fileName: formatPath(iff.paths['a.module.css']),
+          textChanges: [{ start: { line: 3, offset: 10 }, end: { line: 3, offset: 24 }, newText: '@/dd.module.css' }],
         },
       ],
     },

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -26,7 +26,7 @@ const plugin = createLanguageServicePlugin((ts, info) => {
   }
 
   const resolvedConfig = resolveConfig(config, cwd);
-  const resolver = createResolver(resolvedConfig.paths, resolvedConfig.cwd);
+  const resolver = createResolver(resolvedConfig.alias, resolvedConfig.cwd);
   const isExternalFile = createIsExternalFile(resolvedConfig);
 
   return {


### PR DESCRIPTION
This reverts commit 4f3c7a4071eeb25653795c4dd39df4498b4aa78e.

---

With #42, the resolver now uses `ts.resolveModuleName()` to resolve specifiers.

https://github.com/mizdra/honey-css-modules/blob/c3c6cdc9634f3e2d03fa45725b92881cdf2f0b53/packages/core/src/resolver.ts#L22-L31

`ts.resolveModuleName()` is file system independent, but `host` is file system dependent.

This resolver works well in codegen, but not in ts-plugin. ts-plugin also handles files that exist only in the editor's memory. The files do not exist in the file system. This is why the resolver did not work well in ts-plugin.

It is possible to make changes so that host does not depend on the file system. However, I would prefer to revert to the original implementation rather than doing so. The original implementation is simple and does not depend on the file system. It also improves the availability of the core package because it does not depend on the typescript package.
