### PR TITLE
Disallow non-valid class names as JavaScript identifiers

### DIFF
--- a/packages/core/src/parser/rule-parser.test.ts
+++ b/packages/core/src/parser/rule-parser.test.ts
@@ -598,4 +598,50 @@ describe('parseRule', () => {
     //   expect(parseRuleSimply(':is(:global .global1, .global2) {}')).toStrictEqual([]);
     // });
   });
+  test('disallow class names that are not valid JavaScript identifiers', () => {
+    const rules = createRules(
+      createRoot(dedent`
+        .a-1 .a_\u0032 {}
+      `),
+    );
+    const result = rules.map(parseRule);
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "classSelectors": [],
+          "diagnostics": [
+            {
+              "category": "error",
+              "end": {
+                "column": 5,
+                "line": 1,
+              },
+              "filename": "/test/test.css",
+              "start": {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+              "text": "\`a-1\` is not allowed because it is not a valid JavaScript identifier.",
+              "type": "syntactic",
+            },
+            {
+              "category": "error",
+              "end": {
+                "column": 15,
+                "line": 1,
+              },
+              "filename": "/test/test.css",
+              "start": {
+                "column": 6,
+                "line": 1,
+              },
+              "text": "\`a_\\u0032\` is not allowed because it is not a valid JavaScript identifier.",
+              "type": "syntactic",
+            },
+          ],
+        },
+      ]
+    `);
+  });
 });

--- a/packages/ts-plugin/e2e/syntactic-diagnostics.test.ts
+++ b/packages/ts-plugin/e2e/syntactic-diagnostics.test.ts
@@ -10,6 +10,7 @@ test('Syntactic Diagnostics', async () => {
       @value;
       :local(:global(.a_1)) { color: red; }
       :local .a_2 { color: red; }
+      .a-3 { color: red; }
     `,
     'hcm.config.mjs': dedent`
       export default {
@@ -69,6 +70,19 @@ test('Syntactic Diagnostics', async () => {
           "offset": 1,
         },
         "text": "\`:local\` is not supported. Use \`:local(...)\` instead.",
+      },
+      {
+        "category": "error",
+        "code": 0,
+        "end": {
+          "line": 4,
+          "offset": 5,
+        },
+        "start": {
+          "line": 4,
+          "offset": 1,
+        },
+        "text": "\`a-3\` is not allowed because it is not a valid JavaScript identifier.",
       },
     ]
   `);

--- a/packages/ts-plugin/e2e/syntactic-diagnostics.test.ts
+++ b/packages/ts-plugin/e2e/syntactic-diagnostics.test.ts
@@ -8,8 +8,8 @@ test('Syntactic Diagnostics', async () => {
   const iff = await createIFF({
     'a.module.css': dedent`
       @value;
-      :local(:global(.a)) { color: red; }
-      :local .local1 { color: red; }
+      :local(:global(.a_1)) { color: red; }
+      :local .a_2 { color: red; }
     `,
     'hcm.config.mjs': dedent`
       export default {
@@ -49,7 +49,7 @@ test('Syntactic Diagnostics', async () => {
         "code": 0,
         "end": {
           "line": 2,
-          "offset": 19,
+          "offset": 21,
         },
         "start": {
           "line": 2,


### PR DESCRIPTION
## Background

honey-css-modules generates the following .d.ts file.

```css
.a_1 { color: red; }
.a_2 { color: red; }
```

```ts
declare const styles = {
  a_1: '' as readonly string,
  a_2: '' as readonly string,
};
export default styles;
```

Therefore, if a CSS file containing special CSS class names is given, it will generate a .d.ts with invalid syntax.

```css
.a-1 { color: red; }
.\u0066\u006F\u006F { color: red; }
```

```ts
declare const styles = {
  a-1: '' as readonly string,
// ^ invalid syntax
  \u0066\u006F\u006F: '' as readonly string,
//^ invalid syntax
};
export default styles;
```

To avoid this, disallow non-valid class names as JavaScript identifiers.

## Screenshot

<img width="700" alt="image" src="https://github.com/user-attachments/assets/ec9d442d-a2e2-4c59-8b9d-acf15db893b1" />


## References

- [JavaScriptの識別子 - モジュールで使える識別子](https://zenn.dev/qnighy/articles/8ee48a7077d19f#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%A7%E4%BD%BF%E3%81%88%E3%82%8B%E8%AD%98%E5%88%A5%E5%AD%90)
- [JavaScriptの識別子 - プロパティ名](https://zenn.dev/qnighy/articles/8ee48a7077d19f#%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3%E5%90%8D)

## Alternatives

Enclosing class names in quotes can also avoid problems.

```ts
declare const styles = {
  'a-1': '' as readonly string,
  '\u0066\u006F\u006F': '' as readonly string,
};
export default styles;
```

However, this approach seems to break language features such as Find All references and Go to Definition.

- #72 

I have therefore abandoned this approach.
