### PR TITLE
Implement some language features

### DIFF
--- a/example/src/AppHeader.tsx
+++ b/example/src/AppHeader.tsx
@@ -1,0 +1,7 @@
+export function AppHeader() {
+  return (
+    <header>
+      <h1>My App</h1>
+    </header>
+  );
+}

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES5"], // Simplify tsserver.log
     "module": "Preserve",
     "moduleResolution": "bundler",
+    "jsx": "react-jsx",
 
     "noEmit": true,
     "paths": { "@/*": ["./*"] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/eslint": "^9.6.1",
         "@types/node": "^22.10.2",
         "@types/postcss-safe-parser": "^5.0.4",
+        "@types/react": "^19.0.8",
         "@types/vscode": "^1.96.0",
         "@typescript/server-harness": "^0.3.5",
         "dedent": "^1.5.3",
@@ -1191,6 +1192,16 @@
         "postcss": "^8.4.4"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
+      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.96.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
@@ -2149,6 +2160,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.10.2",
     "@types/postcss-safe-parser": "^5.0.4",
+    "@types/react": "^19.0.8",
     "@types/vscode": "^1.96.0",
     "@typescript/server-harness": "^0.3.5",
     "dedent": "^1.5.3",

--- a/packages/core/src/file.test.ts
+++ b/packages/core/src/file.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
-import { findComponentFile, isCSSModuleFile } from './file.js';
+import { findComponentFile, getCssModuleFileName, isComponentFileName, isCSSModuleFile } from './file.js';
 import { createIFF } from './test/fixture.js';
 
 const readFile = async (path: string) => fs.readFile(path, 'utf-8');
@@ -12,6 +13,22 @@ describe('isCSSModuleFile', () => {
     ['a.css', false],
   ])('%s', (input, expected) => {
     expect(isCSSModuleFile(input)).toBe(expected);
+  });
+});
+
+test('getCssModuleFileName', () => {
+  expect(getCssModuleFileName(resolve('/path/to/file.tsx'))).toBe(resolve('/path/to/file.module.css'));
+  expect(getCssModuleFileName(resolve('/path/to/file.ts'))).toBe(resolve('/path/to/file.module.css'));
+});
+
+describe('isComponentFileName', () => {
+  test.each([
+    ['Button.tsx', true],
+    ['Button.jsx', true],
+    ['math.ts', false],
+    ['page.tsx', true],
+  ])('%s', (input, expected) => {
+    expect(isComponentFileName(input)).toBe(expected);
   });
 });
 

--- a/packages/core/src/file.ts
+++ b/packages/core/src/file.ts
@@ -1,13 +1,28 @@
+import path, { join } from 'node:path';
+
+const CSS_MODULE_EXTENSION = '.module.css';
+const COMPONENT_EXTENSIONS = ['.tsx', '.jsx'];
+
 export function isCSSModuleFile(fileName: string): boolean {
-  return fileName.endsWith('.module.css');
+  return fileName.endsWith(CSS_MODULE_EXTENSION);
+}
+
+export function getCssModuleFileName(tsFileName: string): string {
+  const { dir, name } = path.parse(tsFileName);
+  return join(dir, `${name}${CSS_MODULE_EXTENSION}`);
+}
+
+export function isComponentFileName(fileName: string): boolean {
+  // NOTE: Do not check whether it is an upper camel case or not, since lower camel case (e.g. `page.tsx`) is used in Next.js.
+  return COMPONENT_EXTENSIONS.some((ext) => fileName.endsWith(ext));
 }
 
 export async function findComponentFile(
   cssModuleFileName: string,
   readFile: (path: string) => Promise<string>,
 ): Promise<{ fileName: string; text: string } | undefined> {
-  const paths = [cssModuleFileName.replace('.module.css', '.tsx'), cssModuleFileName.replace('.module.css', '.jsx')];
-  for (const path of paths) {
+  const pathWithoutExtension = cssModuleFileName.slice(0, -CSS_MODULE_EXTENSION.length);
+  for (const path of COMPONENT_EXTENSIONS.map((ext) => pathWithoutExtension + ext)) {
     try {
       // TODO: Cache the result of readFile
       // eslint-disable-next-line no-await-in-loop

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,4 +22,4 @@ export {
 export { type CreateDtsOptions, createDts, STYLES_EXPORT_NAME } from './dts-creator.js';
 export { createResolver, type Resolver } from './resolver.js';
 export { type IsExternalFile, createIsExternalFile } from './external-file.js';
-export { isCSSModuleFile, findComponentFile } from './file.js';
+export { getCssModuleFileName, isComponentFileName, isCSSModuleFile, findComponentFile } from './file.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,4 @@ export { type CreateDtsOptions, createDts, STYLES_EXPORT_NAME } from './dts-crea
 export { createResolver, type Resolver } from './resolver.js';
 export { type IsExternalFile, createIsExternalFile } from './external-file.js';
 export { getCssModuleFileName, isComponentFileName, isCSSModuleFile, findComponentFile } from './file.js';
+export { TOKEN_CONSUMER_PATTERN } from './util.js';

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,3 +1,11 @@
 export function isPosixRelativePath(path: string): boolean {
   return path.startsWith(`./`) || path.startsWith(`../`);
 }
+
+/**
+ * The syntax pattern for consuming tokens imported from CSS Module.
+ * @example `styles.foo`
+ */
+// TODO: Support `styles['foo']` and `styles["foo"]`
+// TODO: Support `otherNameStyles.foo`
+export const TOKEN_CONSUMER_PATTERN = /styles\.([$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*)/gu;

--- a/packages/stylelint-plugin/src/util.ts
+++ b/packages/stylelint-plugin/src/util.ts
@@ -1,16 +1,14 @@
 import fs from 'node:fs/promises';
+import { TOKEN_CONSUMER_PATTERN } from 'honey-css-modules-core';
 
 export async function readFile(path: string): Promise<string> {
   return fs.readFile(path, 'utf-8');
 }
 
 export function findUsedTokenNames(componentText: string): Set<string> {
-  // TODO: Support `styles['foo']` and `styles["foo"]`
-  // TODO: Support `otherNameStyles.foo`
-  const pattern = /styles\.([$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*)/gu;
   const usedClassNames = new Set<string>();
   let match;
-  while ((match = pattern.exec(componentText)) !== null) {
+  while ((match = TOKEN_CONSUMER_PATTERN.exec(componentText)) !== null) {
     usedClassNames.add(match[1]!);
   }
   return usedClassNames;

--- a/packages/ts-plugin/e2e/code-fix.test.ts
+++ b/packages/ts-plugin/e2e/code-fix.test.ts
@@ -1,0 +1,82 @@
+import dedent from 'dedent';
+import { describe, expect, test } from 'vitest';
+import { PROPERTY_DOES_NOT_EXIST_ERROR_CODE } from '../src/language-service/feature/code-fix.js';
+import { createIFF } from './test/fixture.js';
+import { formatPath, launchTsserver } from './test/tsserver.js';
+
+describe('Get Code Fixes', async () => {
+  const tsserver = launchTsserver();
+  const iff = await createIFF({
+    'a.tsx': dedent`
+      import styles from './a.module.css';
+      import bStyles from './b.module.css';
+      styles.a_1;
+      bStyles.b_1;
+    `,
+    'a.module.css': '',
+    'b.module.css': '',
+    'hcm.config.mjs': dedent`
+      export default {
+        pattern: '**/*.module.css',
+        dtsOutDir: 'generated',
+      };
+    `,
+    'tsconfig.json': dedent`
+      {
+        "compilerOptions": {}
+      }
+    `,
+  });
+  await tsserver.sendUpdateOpen({
+    openFiles: [{ file: iff.paths['tsconfig.json'] }],
+  });
+  test.each([
+    {
+      name: 'styles.a_1',
+      file: iff.paths['a.tsx'],
+      line: 3,
+      offset: 11,
+      expected: [
+        {
+          fixName: 'fixMissingCSSRule',
+          description: `Add missing CSS rule '.a_1'`,
+          changes: [
+            {
+              fileName: formatPath(iff.paths['a.module.css']),
+              textChanges: [{ start: { line: 1, offset: 1 }, end: { line: 1, offset: 1 }, newText: '\n.a_1 {\n  \n}' }],
+            },
+          ],
+        },
+      ],
+    },
+    // TODO: Pass this test
+    // {
+    //   name: 'bStyles.b_1',
+    //   file: iff.paths['a.tsx'],
+    //   line: 4,
+    //   offset: 12,
+    //   expected: [
+    //     {
+    //       fixName: 'fixMissingCSSRule',
+    //       description: `Add missing CSS rule '.b_1'`,
+    //       changes: [
+    //         {
+    //           fileName: formatPath(iff.paths['b.module.css']),
+    //           textChanges: [{ start: { line: 1, offset: 0 }, end: { line: 1, offset: 0 }, newText: '\n.b_1 {\n  \n}' }],
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // },
+  ])('$name', async ({ file, line, offset, expected }) => {
+    const res = await tsserver.sendGetCodeFixes({
+      errorCodes: [PROPERTY_DOES_NOT_EXIST_ERROR_CODE],
+      file,
+      startLine: line,
+      startOffset: offset,
+      endLine: line,
+      endOffset: offset,
+    });
+    expect(res.body).toStrictEqual(expected);
+  });
+});

--- a/packages/ts-plugin/e2e/completion.test.ts
+++ b/packages/ts-plugin/e2e/completion.test.ts
@@ -1,0 +1,82 @@
+import { join } from 'node:path';
+import dedent from 'dedent';
+import type ts from 'typescript';
+import { describe, expect, test } from 'vitest';
+import { createIFF } from './test/fixture.js';
+import { formatPath, launchTsserver } from './test/tsserver.js';
+
+// eslint-disable-next-line n/no-extraneous-require
+const reactDtsPath = join(require.resolve('@types/react/package.json'), '../index.d.ts');
+
+describe('Completion', async () => {
+  function simplifyEntry(entries: readonly ts.server.protocol.CompletionEntry[]) {
+    return entries.map((entry) => {
+      return {
+        name: entry.name,
+        sortText: entry.sortText,
+        ...('source' in entry ? { source: entry.source } : {}),
+        ...('insertText' in entry ? { insertText: entry.insertText } : {}),
+      };
+    });
+  }
+  const tsserver = launchTsserver();
+  const iff = await createIFF({
+    'a.tsx': dedent`
+      styles;
+      const jsx = <div className />;
+    `,
+    'a.module.css': '',
+    'b.module.css': '',
+    'hcm.config.mjs': dedent`
+      export default {
+        pattern: '**/*.module.css',
+        dtsOutDir: 'generated',
+      };
+    `,
+    'tsconfig.json': dedent`
+      {
+        "compilerOptions": {
+          "jsx": "react-jsx",
+          "types": ["${formatPath(reactDtsPath)}"],
+        }
+      }
+    `,
+  });
+  await tsserver.sendUpdateOpen({
+    openFiles: [{ file: iff.paths['tsconfig.json'] }],
+  });
+  await tsserver.sendConfigure({
+    preferences: {
+      includeCompletionsForModuleExports: true,
+      includeCompletionsWithSnippetText: true,
+      includeCompletionsWithInsertText: true,
+      jsxAttributeCompletionStyle: 'auto',
+    },
+  });
+  test.each([
+    {
+      name: 'styles',
+      file: iff.paths['a.tsx'],
+      line: 1,
+      offset: 7,
+      expected: [
+        { name: 'styles', sortText: '0', source: formatPath(iff.paths['a.module.css']) },
+        { name: 'styles', sortText: '16', source: formatPath(iff.paths['b.module.css']) },
+      ],
+    },
+    {
+      name: 'className',
+      file: iff.paths['a.tsx'],
+      line: 2,
+      offset: 27,
+      expected: [{ name: 'className', insertText: 'className={$1}', sortText: expect.anything() }],
+    },
+  ])('Completions for $name', async ({ name, file, line, offset, expected }) => {
+    const res = await tsserver.sendCompletionInfo({
+      file,
+      line,
+      offset,
+    });
+    expect(simplifyEntry(res.body?.entries.filter((entry) => entry.name === name) ?? [])).toStrictEqual(expected);
+  });
+});

--- a/packages/ts-plugin/e2e/refactor.test.ts
+++ b/packages/ts-plugin/e2e/refactor.test.ts
@@ -1,0 +1,73 @@
+import dedent from 'dedent';
+import { describe, expect, test } from 'vitest';
+import { createCssModuleFileRefactor } from '../src/language-service/feature/refactor.js';
+import { createIFF } from './test/fixture.js';
+import { launchTsserver } from './test/tsserver.js';
+
+describe('Refactor', async () => {
+  const tsserver = launchTsserver();
+  const iff = await createIFF({
+    'a.tsx': '',
+    'b.ts': '',
+    'hcm.config.mjs': dedent`
+      export default {
+        pattern: '**/*.module.css',
+        dtsOutDir: 'generated',
+      };
+    `,
+    'tsconfig.json': dedent`
+      {
+        "compilerOptions": { "jsx": "react-jsx" }
+      }
+    `,
+  });
+  await tsserver.sendUpdateOpen({
+    openFiles: [{ file: iff.paths['a.tsx'] }],
+  });
+  test.each([
+    {
+      name: 'a.tsx',
+      file: iff.paths['a.tsx'],
+      line: 1,
+      offset: 1,
+      expected: [createCssModuleFileRefactor],
+    },
+    {
+      name: 'b.ts',
+      file: iff.paths['b.ts'],
+      line: 1,
+      offset: 1,
+      expected: [],
+    },
+  ])('Get Applicable Refactors for $name', async ({ file, line, offset, expected }) => {
+    const res = await tsserver.sendGetApplicableRefactors({
+      file,
+      line,
+      offset,
+    });
+    expect(res.body).toStrictEqual(expected);
+  });
+  test.each([
+    {
+      name: 'a.tsx',
+      file: iff.paths['a.tsx'],
+      line: 1,
+      offset: 1,
+      expected: [
+        {
+          fileName: iff.join('a.module.css'),
+          textChanges: [{ start: { line: 0, offset: 0 }, end: { line: 0, offset: 0 }, newText: '' }],
+        },
+      ],
+    },
+  ])('Get Edits For Refactor for $name', async ({ file, line, offset, expected }) => {
+    const res = await tsserver.sendGetEditsForRefactor({
+      refactor: createCssModuleFileRefactor.name,
+      action: createCssModuleFileRefactor.actions[0].name,
+      file,
+      line,
+      offset,
+    });
+    expect(res.body?.edits).toStrictEqual(expected);
+  });
+});

--- a/packages/ts-plugin/e2e/test/tsserver.ts
+++ b/packages/ts-plugin/e2e/test/tsserver.ts
@@ -4,6 +4,7 @@ import ts from 'typescript';
 
 interface Tsserver {
   sendUpdateOpen(args: server.protocol.UpdateOpenRequest['arguments']): Promise<server.protocol.Response>;
+  sendConfigure(args: server.protocol.ConfigureRequest['arguments']): Promise<server.protocol.ConfigureResponse>;
   sendDefinitionAndBoundSpan(
     args: server.protocol.FileLocationRequestArgs,
   ): Promise<server.protocol.DefinitionInfoAndBoundSpanResponse>;
@@ -24,6 +25,9 @@ interface Tsserver {
   sendGetEditsForRefactor(
     args: server.protocol.GetEditsForRefactorRequest['arguments'],
   ): Promise<server.protocol.GetEditsForRefactorResponse>;
+  sendCompletionInfo(
+    args: server.protocol.CompletionsRequest['arguments'],
+  ): Promise<server.protocol.CompletionInfoResponse>;
 }
 
 export function launchTsserver(): Tsserver {
@@ -58,6 +62,7 @@ export function launchTsserver(): Tsserver {
 
   return {
     sendUpdateOpen: async (args) => sendRequest(ts.server.protocol.CommandTypes.UpdateOpen, args),
+    sendConfigure: async (args) => sendRequest(ts.server.protocol.CommandTypes.Configure, args),
     sendDefinitionAndBoundSpan: async (args) =>
       sendRequest(ts.server.protocol.CommandTypes.DefinitionAndBoundSpan, args),
     sendReferences: async (args) => sendRequest(ts.server.protocol.CommandTypes.References, args),
@@ -70,6 +75,7 @@ export function launchTsserver(): Tsserver {
     sendGetApplicableRefactors: async (args) =>
       sendRequest(ts.server.protocol.CommandTypes.GetApplicableRefactors, args),
     sendGetEditsForRefactor: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetEditsForRefactor, args),
+    sendCompletionInfo: async (args) => sendRequest(ts.server.protocol.CommandTypes.CompletionInfo, args),
   };
 }
 

--- a/packages/ts-plugin/e2e/test/tsserver.ts
+++ b/packages/ts-plugin/e2e/test/tsserver.ts
@@ -18,6 +18,12 @@ interface Tsserver {
   sendGetEditsForFileRename(
     args: server.protocol.GetEditsForFileRenameRequest['arguments'],
   ): Promise<server.protocol.GetEditsForFileRenameResponse>;
+  sendGetApplicableRefactors(
+    args: server.protocol.GetApplicableRefactorsRequest['arguments'],
+  ): Promise<server.protocol.GetApplicableRefactorsResponse>;
+  sendGetEditsForRefactor(
+    args: server.protocol.GetEditsForRefactorRequest['arguments'],
+  ): Promise<server.protocol.GetEditsForRefactorResponse>;
 }
 
 export function launchTsserver(): Tsserver {
@@ -61,6 +67,9 @@ export function launchTsserver(): Tsserver {
     sendSyntacticDiagnosticsSync: async (args) =>
       sendRequest(ts.server.protocol.CommandTypes.SyntacticDiagnosticsSync, args),
     sendGetEditsForFileRename: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetEditsForFileRename, args),
+    sendGetApplicableRefactors: async (args) =>
+      sendRequest(ts.server.protocol.CommandTypes.GetApplicableRefactors, args),
+    sendGetEditsForRefactor: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetEditsForRefactor, args),
   };
 }
 

--- a/packages/ts-plugin/e2e/test/tsserver.ts
+++ b/packages/ts-plugin/e2e/test/tsserver.ts
@@ -1,6 +1,6 @@
 import serverHarness from '@typescript/server-harness';
 import type { server } from 'typescript';
-import type ts from 'typescript';
+import ts from 'typescript';
 
 interface Tsserver {
   sendUpdateOpen(args: server.protocol.UpdateOpenRequest['arguments']): Promise<server.protocol.Response>;
@@ -51,13 +51,16 @@ export function launchTsserver(): Tsserver {
   }
 
   return {
-    sendUpdateOpen: async (args) => sendRequest('updateOpen', args),
-    sendDefinitionAndBoundSpan: async (args) => sendRequest('definitionAndBoundSpan', args),
-    sendReferences: async (args) => sendRequest('references', args),
-    sendRename: async (args) => sendRequest('rename', args),
-    sendSemanticDiagnosticsSync: async (args) => sendRequest('semanticDiagnosticsSync', args),
-    sendSyntacticDiagnosticsSync: async (args) => sendRequest('syntacticDiagnosticsSync', args),
-    sendGetEditsForFileRename: async (args) => sendRequest('getEditsForFileRename', args),
+    sendUpdateOpen: async (args) => sendRequest(ts.server.protocol.CommandTypes.UpdateOpen, args),
+    sendDefinitionAndBoundSpan: async (args) =>
+      sendRequest(ts.server.protocol.CommandTypes.DefinitionAndBoundSpan, args),
+    sendReferences: async (args) => sendRequest(ts.server.protocol.CommandTypes.References, args),
+    sendRename: async (args) => sendRequest(ts.server.protocol.CommandTypes.Rename, args),
+    sendSemanticDiagnosticsSync: async (args) =>
+      sendRequest(ts.server.protocol.CommandTypes.SemanticDiagnosticsSync, args),
+    sendSyntacticDiagnosticsSync: async (args) =>
+      sendRequest(ts.server.protocol.CommandTypes.SyntacticDiagnosticsSync, args),
+    sendGetEditsForFileRename: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetEditsForFileRename, args),
   };
 }
 

--- a/packages/ts-plugin/e2e/test/tsserver.ts
+++ b/packages/ts-plugin/e2e/test/tsserver.ts
@@ -28,6 +28,7 @@ interface Tsserver {
   sendCompletionInfo(
     args: server.protocol.CompletionsRequest['arguments'],
   ): Promise<server.protocol.CompletionInfoResponse>;
+  sendGetCodeFixes(args: server.protocol.CodeFixRequest['arguments']): Promise<server.protocol.GetCodeFixesResponse>;
 }
 
 export function launchTsserver(): Tsserver {
@@ -76,6 +77,7 @@ export function launchTsserver(): Tsserver {
       sendRequest(ts.server.protocol.CommandTypes.GetApplicableRefactors, args),
     sendGetEditsForRefactor: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetEditsForRefactor, args),
     sendCompletionInfo: async (args) => sendRequest(ts.server.protocol.CommandTypes.CompletionInfo, args),
+    sendGetCodeFixes: async (args) => sendRequest(ts.server.protocol.CommandTypes.GetCodeFixes, args),
   };
 }
 

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -32,7 +32,7 @@ const plugin = createLanguageServicePlugin((ts, info) => {
   return {
     languagePlugins: [createCSSModuleLanguagePlugin(resolvedConfig, resolver, isExternalFile)],
     setup: (language) => {
-      info.languageService = proxyLanguageService(language, info.languageService);
+      info.languageService = proxyLanguageService(language, info.languageService, info.project);
     },
   };
 });

--- a/packages/ts-plugin/src/language-service/feature/code-fix.ts
+++ b/packages/ts-plugin/src/language-service/feature/code-fix.ts
@@ -1,0 +1,107 @@
+import type { Language } from '@volar/language-core';
+import { isComponentFileName, TOKEN_CONSUMER_PATTERN } from 'honey-css-modules-core';
+import ts from 'typescript';
+
+// ref: https://github.com/microsoft/TypeScript/blob/220706eb0320ff46fad8bf80a5e99db624ee7dfb/src/compiler/diagnosticMessages.json#L2051-L2054
+export const PROPERTY_DOES_NOT_EXIST_ERROR_CODE = 2339;
+
+export function getCodeFixesAtPosition(
+  language: Language<string>,
+  languageService: ts.LanguageService,
+  project: ts.server.Project,
+): ts.LanguageService['getCodeFixesAtPosition'] {
+  // eslint-disable-next-line max-params
+  return (fileName, start, end, errorCodes, formatOptions, preferences) => {
+    const prior = Array.from(
+      languageService.getCodeFixesAtPosition(fileName, start, end, errorCodes, formatOptions, preferences) ?? [],
+    );
+
+    if (isComponentFileName(fileName)) {
+      // If a user is trying to use a non-existent token (e.g. `styles.nonExistToken`), provide a code fix to add the token.
+      if (errorCodes.includes(PROPERTY_DOES_NOT_EXIST_ERROR_CODE)) {
+        const tokenConsumer = getTokenConsumerAtPosition(fileName, start, project, languageService);
+        if (tokenConsumer) {
+          prior.push({
+            fixName: 'fixMissingCSSRule',
+            description: `Add missing CSS rule '.${tokenConsumer.tokenName}'`,
+            changes: [createInsertRuleFileChange(tokenConsumer.from, tokenConsumer.tokenName, language)],
+          });
+        }
+      }
+    }
+
+    return prior;
+  };
+}
+
+interface TokenConsumer {
+  /** The token name (e.g. `foo` in `styles.foo`) */
+  tokenName: string;
+  /** The file path of the CSS module that defines the token */
+  from: string;
+}
+
+/**
+ * Get the token consumer at the specified position.
+ * If the position is at `styles.foo`, it returns `{ tokenName: 'foo', from: '/path/to/a.module.css' }`.
+ */
+function getTokenConsumerAtPosition(
+  fileName: string,
+  position: number,
+  project: ts.server.Project,
+  languageService: ts.LanguageService,
+): TokenConsumer | undefined {
+  const sourceFile = project.getSourceFile(project.projectService.toPath(fileName));
+  if (!sourceFile) return undefined;
+  const stylesPropertyAccessExpression = getStylesPropertyAccessExpression(sourceFile, position);
+  if (!stylesPropertyAccessExpression) return undefined;
+  const definitions = languageService.getDefinitionAtPosition(
+    fileName,
+    stylesPropertyAccessExpression.expression.getStart(),
+  );
+  if (definitions && definitions[0]) {
+    return { tokenName: stylesPropertyAccessExpression.name.text, from: definitions[0].fileName };
+  } else {
+    return undefined;
+  }
+}
+
+/** Get the `styles` property access expression at the specified position. (e.g. `styles.foo`) */
+function getStylesPropertyAccessExpression(
+  sourceFile: ts.SourceFile,
+  position: number,
+): ts.PropertyAccessExpression | undefined {
+  function getStylesPropertyAccessExpressionImpl(node: ts.Node): ts.PropertyAccessExpression | undefined {
+    if (
+      node.pos <= position &&
+      position <= node.end &&
+      ts.isPropertyAccessExpression(node) &&
+      TOKEN_CONSUMER_PATTERN.test(node.getText())
+    ) {
+      return node;
+    }
+    return ts.forEachChild(node, getStylesPropertyAccessExpressionImpl);
+  }
+  return getStylesPropertyAccessExpressionImpl(sourceFile);
+}
+
+function createInsertRuleFileChange(
+  cssModuleFileName: string,
+  className: string,
+  language: Language<string>,
+): ts.FileTextChanges {
+  const script = language.scripts.get(cssModuleFileName);
+  if (script) {
+    return {
+      fileName: cssModuleFileName,
+      textChanges: [{ span: { start: script.snapshot.getLength(), length: 0 }, newText: `\n.${className} {\n  \n}` }],
+      isNewFile: false,
+    };
+  } else {
+    return {
+      fileName: cssModuleFileName,
+      textChanges: [{ span: { start: 0, length: 0 }, newText: `.${className} {\n  \n}\n\n` }],
+      isNewFile: true,
+    };
+  }
+}

--- a/packages/ts-plugin/src/language-service/feature/completion.ts
+++ b/packages/ts-plugin/src/language-service/feature/completion.ts
@@ -1,0 +1,50 @@
+import { resolve } from 'node:path';
+import { getCssModuleFileName, isComponentFileName, STYLES_EXPORT_NAME } from 'honey-css-modules-core';
+import ts from 'typescript';
+
+export function getCompletionsAtPosition(
+  languageService: ts.LanguageService,
+): ts.LanguageService['getCompletionsAtPosition'] {
+  return (fileName, position, options, formattingSettings) => {
+    const prior = languageService.getCompletionsAtPosition(fileName, position, options, formattingSettings);
+
+    if (isComponentFileName(fileName) && prior) {
+      const cssModuleFileName = getCssModuleFileName(fileName);
+      for (const entry of prior.entries) {
+        if (isStylesEntryForCSSModuleFile(entry, cssModuleFileName)) {
+          // Prioritize the completion of the `styles' import for the current .ts file for usability.
+          // NOTE: This is a hack to make the completion item appear at the top
+          entry.sortText = '0';
+        } else if (isClassNamePropEntry(entry)) {
+          // Complete `className={...}` instead of `className="..."` for usability.
+          entry.insertText = 'className={$1}';
+        }
+      }
+    }
+    return prior;
+  };
+}
+
+/**
+ * Check if the completion entry is the `styles` entry for the CSS module file.
+ */
+function isStylesEntryForCSSModuleFile(entry: ts.CompletionEntry, cssModuleFileName: string) {
+  return (
+    entry.name === STYLES_EXPORT_NAME &&
+    entry.data &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+    entry.data.exportName === ts.InternalSymbolName.Default &&
+    entry.data.fileName &&
+    // NOTE: In windows, `entry.data.fileName` is separated by `/`, but `cssModuleFileName` is separated by `\`. So we use `resolve` to normalize the path.
+    resolve(entry.data.fileName) === cssModuleFileName
+  );
+}
+
+function isClassNamePropEntry(entry: ts.CompletionEntry) {
+  return (
+    entry.name === 'className' &&
+    entry.kind === ts.ScriptElementKind.memberVariableElement &&
+    entry.insertText === 'className="$1"' &&
+    entry.isSnippet
+  );
+}

--- a/packages/ts-plugin/src/language-service/feature/refactor.ts
+++ b/packages/ts-plugin/src/language-service/feature/refactor.ts
@@ -1,0 +1,52 @@
+import { getCssModuleFileName, isComponentFileName } from 'honey-css-modules-core';
+import type ts from 'typescript';
+
+export const createCssModuleFileRefactor = {
+  name: 'Create CSS Module file',
+  description: 'Create CSS Module file',
+  actions: [{ name: 'Create CSS Module file', description: 'Create CSS Module file for current file' }],
+} as const satisfies ts.ApplicableRefactorInfo;
+
+export function getApplicableRefactors(
+  languageService: ts.LanguageService,
+  project: ts.server.Project,
+): ts.LanguageService['getApplicableRefactors'] {
+  return (fileName, positionOrRange, preferences) => {
+    const prior = languageService.getApplicableRefactors(fileName, positionOrRange, preferences) ?? [];
+    if (isComponentFileName(fileName)) {
+      // If the CSS Module file does not exist, provide a refactor to create it.
+      if (!project.fileExists(getCssModuleFileName(fileName))) {
+        prior.push(createCssModuleFileRefactor);
+      }
+    }
+    return prior;
+  };
+}
+
+export function getEditsForRefactor(languageService: ts.LanguageService): ts.LanguageService['getEditsForRefactor'] {
+  // eslint-disable-next-line max-params
+  return (fileName, formatOptions, positionOrRange, refactorName, actionName, preferences) => {
+    const prior = languageService.getEditsForRefactor(
+      fileName,
+      formatOptions,
+      positionOrRange,
+      refactorName,
+      actionName,
+      preferences,
+    ) ?? { edits: [] };
+    if (isComponentFileName(fileName)) {
+      if (refactorName === createCssModuleFileRefactor.name) {
+        prior.edits.push(createNewCssModuleFileChange(getCssModuleFileName(fileName)));
+      }
+    }
+    return prior;
+  };
+}
+
+function createNewCssModuleFileChange(cssFilename: string): ts.FileTextChanges {
+  return {
+    fileName: cssFilename,
+    textChanges: [{ span: { start: 0, length: 0 }, newText: '' }],
+    isNewFile: true,
+  };
+}

--- a/packages/ts-plugin/src/language-service/proxy.ts
+++ b/packages/ts-plugin/src/language-service/proxy.ts
@@ -1,5 +1,6 @@
 import type { Language } from '@volar/language-core';
 import type ts from 'typescript';
+import { getCodeFixesAtPosition } from './feature/code-fix.js';
 import { getCompletionsAtPosition } from './feature/completion.js';
 import { getApplicableRefactors, getEditsForRefactor } from './feature/refactor.js';
 import { getSyntacticDiagnostics } from './feature/syntactic-diagnostic.js';
@@ -22,6 +23,7 @@ export function proxyLanguageService(
   proxy.getApplicableRefactors = getApplicableRefactors(languageService, project);
   proxy.getEditsForRefactor = getEditsForRefactor(languageService);
   proxy.getCompletionsAtPosition = getCompletionsAtPosition(languageService);
+  proxy.getCodeFixesAtPosition = getCodeFixesAtPosition(language, languageService, project);
 
   return proxy;
 }

--- a/packages/ts-plugin/src/language-service/proxy.ts
+++ b/packages/ts-plugin/src/language-service/proxy.ts
@@ -1,5 +1,6 @@
 import type { Language } from '@volar/language-core';
 import type ts from 'typescript';
+import { getCompletionsAtPosition } from './feature/completion.js';
 import { getApplicableRefactors, getEditsForRefactor } from './feature/refactor.js';
 import { getSyntacticDiagnostics } from './feature/syntactic-diagnostic.js';
 
@@ -20,6 +21,7 @@ export function proxyLanguageService(
   proxy.getSyntacticDiagnostics = getSyntacticDiagnostics(language, languageService);
   proxy.getApplicableRefactors = getApplicableRefactors(languageService, project);
   proxy.getEditsForRefactor = getEditsForRefactor(languageService);
+  proxy.getCompletionsAtPosition = getCompletionsAtPosition(languageService);
 
   return proxy;
 }

--- a/packages/ts-plugin/src/language-service/proxy.ts
+++ b/packages/ts-plugin/src/language-service/proxy.ts
@@ -1,10 +1,12 @@
 import type { Language } from '@volar/language-core';
 import type ts from 'typescript';
+import { getApplicableRefactors, getEditsForRefactor } from './feature/refactor.js';
 import { getSyntacticDiagnostics } from './feature/syntactic-diagnostic.js';
 
 export function proxyLanguageService(
   language: Language<string>,
   languageService: ts.LanguageService,
+  project: ts.server.Project,
 ): ts.LanguageService {
   const proxy: ts.LanguageService = Object.create(null);
 
@@ -16,6 +18,8 @@ export function proxyLanguageService(
   }
 
   proxy.getSyntacticDiagnostics = getSyntacticDiagnostics(language, languageService);
+  proxy.getApplicableRefactors = getApplicableRefactors(languageService, project);
+  proxy.getEditsForRefactor = getEditsForRefactor(languageService);
 
   return proxy;
 }


### PR DESCRIPTION
## Overview

https://github.com/user-attachments/assets/07e41ecf-e4ea-4d9e-a741-e7a17163ea2e

## Features

<details>
<summary>Create CSS Module file for current file</summary>

If there is no CSS Module file corresponding to `xxx.tsx`, create one.

https://github.com/user-attachments/assets/05f9e839-9617-43dc-a519-d5a20adf1146

</details>

<details>
<summary>Complete `className={...}` instead of `className="..."`</summary>

In projects where CSS Modules are used, the element is styled with `className={styles.xxx}`. However, when you type `className`, `className="..."` is completed. This is annoying to the user.

So, instead of `className="..."` instead of `className={...}` instead of `className="..."`.

https://github.com/user-attachments/assets/b3609c8a-123f-4f4b-af8c-3c8bf7ab4363

</details>

<details>
<summary>Prioritize the `styles' import for the current component file</summary>

When you request `styles` completion, the CSS Module file `styles` will be suggested. If there are many CSS Module files in the project, more items will be suggested. This can be confusing to the user.

So I have made it so that the `styles` of the CSS Module file corresponding to the current file is shown first.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/413373ec-1258-484d-9248-bc173e4f6d4a" />

</details>

<details>
<summary>Add missing CSS rule</summary>

If you are trying to use a class name that is not defined, you can add it with Quick Fixes.

https://github.com/user-attachments/assets/3502150a-985d-45f3-9912-bbc183e41c03

</details>


