### PR TITLE
Add `core` to dependencies of `codegen` and `ts-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6412,6 +6412,9 @@
       "name": "honey-css-modules",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "honey-css-modules-core": "^0.0.0"
+      },
       "bin": {
         "hcm": "bin/hcm.mjs"
       },
@@ -6419,7 +6422,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "honey-css-modules-core": "../core"
+        "typescript": "^5.7.3"
       }
     },
     "packages/core": {
@@ -6455,11 +6458,13 @@
       "name": "stylelint-plugin-honey-css-modules",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "honey-css-modules-core": "^0.0.0"
+      },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "honey-css-modules-core": "../core",
         "stylelint": "^16.0.0"
       }
     },
@@ -6485,13 +6490,13 @@
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "^2.4.11",
-        "@volar/typescript": "^2.4.11"
+        "@volar/typescript": "^2.4.11",
+        "honey-css-modules-core": "^0.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "honey-css-modules-core": "../core",
         "typescript": ">=5.6.3"
       }
     },

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -45,9 +45,10 @@
     "!src/test",
     "dist"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "honey-css-modules-core": "^0.0.0"
+  },
   "peerDependencies": {
-    "honey-css-modules-core": "../core",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -36,8 +36,10 @@
     "!src/test",
     "dist"
   ],
+  "dependencies": {
+    "honey-css-modules-core": "^0.0.0"
+  },
   "peerDependencies": {
-    "stylelint": "^16.0.0",
-    "honey-css-modules-core": "../core"
+    "stylelint": "^16.0.0"
   }
 }

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -37,10 +37,10 @@
   ],
   "dependencies": {
     "@volar/language-core": "^2.4.11",
-    "@volar/typescript": "^2.4.11"
+    "@volar/typescript": "^2.4.11",
+    "honey-css-modules-core": "^0.0.0"
   },
   "peerDependencies": {
-    "honey-css-modules-core": "../core",
     "typescript": ">=5.6.3"
   }
 }


### PR DESCRIPTION
`codegen` and `ts-plugin` are not plugins for core. So, we should add `core` to dependencies of `codegen` and `ts-plugin`