### PR TITLE
Support `extends` of `tsconfig.json`

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -243,6 +243,29 @@ describe('readTsConfigFile', () => {
         arbitraryExtensions: true,
       });
     });
+    test('ignores un-existing files', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': dedent`
+          {
+            "extends": "./un-existing.json",
+            "hcmOptions": { "dtsOutDir": "generated/hcm" }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": ["./tsconfig.base.json", "./un-existing.json"],
+            "hcmOptions": { "arbitraryExtensions": true }
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: undefined,
+        excludes: undefined,
+        paths: undefined,
+        dtsOutDir: 'generated/hcm',
+        arbitraryExtensions: true,
+      });
+    });
   });
 });
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -116,6 +116,134 @@ describe('readTsConfigFile', () => {
     const iff = await createIFF({});
     expect(() => readTsConfigFile(iff.rootDir)).toThrow(TsConfigFileNotFoundError);
   });
+  describe('supports `extends`', () => {
+    test('inherits from a file', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': dedent`
+          {
+            "hcmOptions": { "dtsOutDir": "generated/hcm" }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": "./tsconfig.base.json",
+            "hcmOptions": { "arbitraryExtensions": true }
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: undefined,
+        excludes: undefined,
+        paths: undefined,
+        dtsOutDir: 'generated/hcm',
+        arbitraryExtensions: true,
+      });
+    });
+    test('does not merge arrays and objects, but overwrites them', async () => {
+      const iff = await createIFF({
+        'tsconfig.base.json': dedent`
+          {
+            "include": ["include1"],
+            "exclude": ["exclude1"],
+            "compilerOptions": {
+              "paths": { "@/*": ["./paths1/*"] }
+            }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": "./tsconfig.base.json",
+            "include": ["include2"],
+            "exclude": ["exclude2"],
+            "compilerOptions": {
+              "paths": { "@/*": ["./paths2/*"], "#/*": ["./paths2/*"] }
+            }
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: ['include2'],
+        excludes: ['exclude2'],
+        paths: { '@/*': ['./paths2/*'], '#/*': ['./paths2/*'] },
+        dtsOutDir: undefined,
+        arbitraryExtensions: undefined,
+      });
+    });
+    test('inherits from a file recursively', async () => {
+      const iff = await createIFF({
+        'tsconfig.base1.json': dedent`
+          {
+            "hcmOptions": { "dtsOutDir": "generated/hcm" },
+          }
+        `,
+        'tsconfig.base2.json': dedent`
+          {
+            "extends": "./tsconfig.base1.json",
+            "hcmOptions": { "arbitraryExtensions": true }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": "./tsconfig.base2.json"
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: undefined,
+        excludes: undefined,
+        paths: undefined,
+        dtsOutDir: 'generated/hcm',
+        arbitraryExtensions: true,
+      });
+    });
+    test('inherits from a package', async () => {
+      const iff = await createIFF({
+        'node_modules/some-pkg/tsconfig.json': dedent`
+          {
+            "hcmOptions": { "dtsOutDir": "generated/hcm" }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": "some-pkg/tsconfig.json"
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: undefined,
+        excludes: undefined,
+        paths: undefined,
+        dtsOutDir: 'generated/hcm',
+        arbitraryExtensions: undefined,
+      });
+    });
+    test('inherits from multiple files', async () => {
+      const iff = await createIFF({
+        'tsconfig.base1.json': dedent`
+          {
+            "hcmOptions": { "dtsOutDir": "generated/hcm" }
+          }
+        `,
+        'tsconfig.base2.json': dedent`
+          {
+            "hcmOptions": { "arbitraryExtensions": true }
+          }
+        `,
+        'tsconfig.json': dedent`
+          {
+            "extends": ["./tsconfig.base1.json", "./tsconfig.base2.json"]
+          }
+        `,
+      });
+      expect(readTsConfigFile(iff.rootDir).config).toEqual({
+        includes: undefined,
+        excludes: undefined,
+        paths: undefined,
+        dtsOutDir: 'generated/hcm',
+        arbitraryExtensions: true,
+      });
+    });
+  });
 });
 
 describe('normalizeConfig', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -87,6 +87,10 @@ function parseRawData(raw: unknown, configFileName: string): ParsedRawData {
     diagnostics: [],
   };
   if (typeof raw !== 'object' || raw === null) return result;
+
+  // `tsConfigSourceFile.configFileSpecs` contains `includes` and `excludes`. However, it is an internal API.
+  // So we collect `includes` and `excludes` from `parsedCommandLine.raw` without the internal API.
+
   if ('include' in raw) {
     if (Array.isArray(raw.include)) {
       const includes = raw.include.filter((i) => typeof i === 'string');
@@ -222,9 +226,11 @@ export function readTsConfigFile(project: string): {
       },
     ],
   );
+  // Read options from `parsedCommandLine.raw`
   let parsedRawData = parseRawData(parsedCommandLine.raw, configFileName);
 
-  // Inherit options from the base config
+  // The options read from `parsedCommandLine.raw` do not inherit values from the file specified in `extends`.
+  // So here we read the options from those files and merge them into `parsedRawData`.
   if (tsConfigSourceFile.extendedSourceFiles) {
     for (const extendedSourceFile of tsConfigSourceFile.extendedSourceFiles) {
       let base: ParsedRawData;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -227,7 +227,13 @@ export function readTsConfigFile(project: string): {
   // Inherit options from the base config
   if (tsConfigSourceFile.extendedSourceFiles) {
     for (const extendedSourceFile of tsConfigSourceFile.extendedSourceFiles) {
-      const base = readTsConfigFile(extendedSourceFile);
+      let base: ParsedRawData;
+      try {
+        base = readTsConfigFile(extendedSourceFile);
+      } catch (error) {
+        if (error instanceof TsConfigFileNotFoundError) continue;
+        throw error;
+      }
       parsedRawData = mergeParsedRawData(base, parsedRawData);
     }
   }


### PR DESCRIPTION
ref: #86 

## Background

In `tsconfig.json`, the `extends` option allows you to inherit values from other configuration files.

```jsonc
// tsconfig.base.json
{
  "compilerOptions": {
    "esModuleInterop": true,
    "strict": true"
  }
}
```

```jsonc
// tsconfig.json
{
  "extends": "./tsconfig.base.json",
  "compilerOptions": {
    "target": "ES2022",
    "module": "NodeNext"
  }
}
```

In the above example, `tsconfig.json` is equivalent to the following:

```jsonc
{
  "compilerOptions": {
    "esModuleInterop": true,
    "strict": true",
    "target": "ES2022",
    "module": "NodeNext"
  }
}
```

`extends` basically inherits all options. The exception is the `references` option.

https://www.typescriptlang.org/tsconfig/#extends
> Currently, the only top-level property that is excluded from inheritance is references.

## Problem

And options specific to 3rd-party libraries are not inherited. This is undocumented behavior.

```jsonc
// tsconfig.base.json
{
  "hcmOptions": {
    "dtsOutDir": "generated"
  }
}
```

```jsonc
// tsconfig.json
{
  "extends": "./tsconfig.base.json",
  "compilerOptions": {
    "target": "ES2022",
    "module": "NodeNext"
  }
}
```

In the above example, `tsconfig.json` is equivalent to the following:

```jsonc
{
  "compilerOptions": {
    "target": "ES2022",
    "module": "NodeNext"
  }
  // `hcmOptions.dtsOutDir` is missing...
}
```

This behavior may confuse users.

## Solution

Make `extends` inherit `hcmOptions`.


## Prior Case
- vuejs/language-tools inherits `vueCompilerOptions` with `extends`.
  - https://github.com/vuejs/language-tools/blob/b6580514e659cc1aab0676fe418ba0a5e2f0ead3/packages/language-core/lib/utils/ts.ts#L84-L91