### PR TITLE
Revert "refactor: move language plugin to `core`"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6430,7 +6430,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "^2.4.11",
         "postcss": "^8.4.49",
         "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
     "dist"
   ],
   "dependencies": {
-    "@volar/language-core": "^2.4.11",
     "postcss": "^8.4.49",
     "postcss-safe-parser": "^7.0.1",
     "postcss-selector-parser": "^7.1.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,4 +36,3 @@ export {
 export { checkCSSModule } from './checker.js';
 export { type ExportBuilder, createExportBuilder } from './export-builder.js';
 export { join, resolve, relative, dirname, basename, parse, matchesGlob, isAbsolute } from './path.js';
-export { createCSSModuleLanguagePlugin, isCSSModuleScript, HCM_DATA_KEY } from './language-plugin.js';

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,12 +1,8 @@
 import { createLanguageServicePlugin } from '@volar/typescript/lib/quickstart/createLanguageServicePlugin.js';
 import type { HCMConfig } from 'honey-css-modules-core';
-import {
-  createCSSModuleLanguagePlugin,
-  createMatchesPattern,
-  createResolver,
-  readConfigFile,
-} from 'honey-css-modules-core';
+import { createMatchesPattern, createResolver, readConfigFile } from 'honey-css-modules-core';
 import { TsConfigFileNotFoundError } from 'honey-css-modules-core';
+import { createCSSModuleLanguagePlugin } from './language-plugin.js';
 import { proxyLanguageService } from './language-service/proxy.js';
 
 const plugin = createLanguageServicePlugin((ts, info) => {

--- a/packages/ts-plugin/src/language-plugin.ts
+++ b/packages/ts-plugin/src/language-plugin.ts
@@ -1,13 +1,8 @@
 import type { LanguagePlugin, SourceScript, VirtualCode } from '@volar/language-core';
 import type {} from '@volar/typescript';
+import type { CSSModule, HCMConfig, MatchesPattern, Resolver, SyntacticDiagnostic } from 'honey-css-modules-core';
+import { createDts, parseCSSModule } from 'honey-css-modules-core';
 import ts from 'typescript';
-import type { HCMConfig } from './config.js';
-import type { SyntacticDiagnostic } from './diagnostic.js';
-import { createDts } from './dts-creator.js';
-import type { MatchesPattern } from './file.js';
-import type { CSSModule } from './parser/css-module-parser.js';
-import { parseCSSModule } from './parser/css-module-parser.js';
-import type { Resolver } from './resolver.js';
 
 export const LANGUAGE_ID = 'css-module';
 

--- a/packages/ts-plugin/src/language-service/feature/code-fix.ts
+++ b/packages/ts-plugin/src/language-service/feature/code-fix.ts
@@ -1,6 +1,7 @@
 import type { Language } from '@volar/language-core';
-import { isComponentFileName, isCSSModuleScript } from 'honey-css-modules-core';
+import { isComponentFileName } from 'honey-css-modules-core';
 import ts from 'typescript';
+import { isCSSModuleScript } from '../../language-plugin.js';
 
 // ref: https://github.com/microsoft/TypeScript/blob/220706eb0320ff46fad8bf80a5e99db624ee7dfb/src/compiler/diagnosticMessages.json#L2051-L2054
 export const PROPERTY_DOES_NOT_EXIST_ERROR_CODE = 2339;

--- a/packages/ts-plugin/src/language-service/feature/semantic-diagnostic.ts
+++ b/packages/ts-plugin/src/language-service/feature/semantic-diagnostic.ts
@@ -1,7 +1,8 @@
 import type { Language } from '@volar/language-core';
 import type { CSSModule, ExportBuilder, MatchesPattern, Resolver, SemanticDiagnostic } from 'honey-css-modules-core';
-import { checkCSSModule, HCM_DATA_KEY, isCSSModuleScript } from 'honey-css-modules-core';
+import { checkCSSModule } from 'honey-css-modules-core';
 import ts from 'typescript';
+import { HCM_DATA_KEY, isCSSModuleScript } from '../../language-plugin.js';
 import { convertErrorCategory, TS_ERROR_CODE_FOR_HCM_ERROR } from '../../util.js';
 
 // eslint-disable-next-line max-params

--- a/packages/ts-plugin/src/language-service/feature/syntactic-diagnostic.ts
+++ b/packages/ts-plugin/src/language-service/feature/syntactic-diagnostic.ts
@@ -1,6 +1,7 @@
 import type { Language } from '@volar/language-core';
-import { HCM_DATA_KEY, isCSSModuleScript, type SyntacticDiagnostic } from 'honey-css-modules-core';
+import type { SyntacticDiagnostic } from 'honey-css-modules-core';
 import ts from 'typescript';
+import { HCM_DATA_KEY, isCSSModuleScript } from '../../language-plugin.js';
 import { convertErrorCategory, TS_ERROR_CODE_FOR_HCM_ERROR } from '../../util.js';
 
 export function getSyntacticDiagnostics(

--- a/packages/ts-plugin/src/language-service/proxy.ts
+++ b/packages/ts-plugin/src/language-service/proxy.ts
@@ -1,12 +1,7 @@
 import type { Language } from '@volar/language-core';
-import {
-  createExportBuilder,
-  HCM_DATA_KEY,
-  isCSSModuleScript,
-  type MatchesPattern,
-  type Resolver,
-} from 'honey-css-modules-core';
+import { createExportBuilder, type MatchesPattern, type Resolver } from 'honey-css-modules-core';
 import type ts from 'typescript';
+import { HCM_DATA_KEY, isCSSModuleScript } from '../language-plugin.js';
 import { getCodeFixesAtPosition } from './feature/code-fix.js';
 import { getCompletionsAtPosition } from './feature/completion.js';
 import { getApplicableRefactors, getEditsForRefactor } from './feature/refactor.js';


### PR DESCRIPTION
This reverts commit 1e1a38740f80f8bf7e1a1dc0ad622183176e63c3.